### PR TITLE
Add cleaned datasets and simple quiz UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+cleaned/
+*.pyc
+.env

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+from flask import Flask, render_template, jsonify, request
+import json
+from pathlib import Path
+import random
+
+app = Flask(__name__)
+
+DATA_DIR = Path("cleaned") if Path("cleaned").exists() else Path("output")
+
+
+def _list_files():
+    return [p for p in DATA_DIR.glob("*.json")]
+
+
+def _bank_mapping():
+    banks = {}
+    for p in _list_files():
+        base = p.stem.replace("_questions", "")
+        base = base.replace("_low", "").replace("_medium", "").replace("_high", "")
+        banks.setdefault(base, []).append(p)
+    return banks
+
+BANKS = _bank_mapping()
+
+
+def _load(path: Path):
+    return json.loads(path.read_text())
+
+
+@app.route("/")
+def index():
+    return render_template("index.html", banks=sorted(BANKS))
+
+
+@app.route("/question")
+def question():
+    bank = request.args.get("bank")
+    if bank not in BANKS:
+        return jsonify({"error": "unknown bank"}), 404
+    file = random.choice(BANKS[bank])
+    data = _load(file)
+    q = random.choice(data)
+    return jsonify(q)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=3.0
+Unidecode>=1.3

--- a/scripts/clean_questions.py
+++ b/scripts/clean_questions.py
@@ -1,0 +1,50 @@
+import json
+import unicodedata
+import re
+from unidecode import unidecode
+from pathlib import Path
+
+INPUT_DIR = Path("output")
+OUTPUT_DIR = Path("cleaned")
+
+
+def clean_text(text: str) -> str:
+    """Normalize whitespace and punctuation."""
+    if not isinstance(text, str):
+        return text
+    # Replace newlines encoded in json
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    # Normalize unicode characters
+    text = unicodedata.normalize("NFKC", text)
+    text = unidecode(text)
+    # Replace non-breaking spaces
+    text = text.replace("\u00a0", " ")
+    # Collapse whitespace
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def process_file(path: Path) -> list:
+    data = json.loads(path.read_text())
+    for q in data:
+        for key in ("title", "text", "why", "correct_answer"):
+            if key in q and q[key]:
+                q[key] = clean_text(q[key])
+        if "answers" in q:
+            for ans in q["answers"]:
+                if "text" in ans and ans["text"]:
+                    ans["text"] = clean_text(ans["text"])
+    return data
+
+
+def main():
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    for file in INPUT_DIR.glob("*.json"):
+        cleaned = process_file(file)
+        out_path = OUTPUT_DIR / file.name
+        out_path.write_text(json.dumps(cleaned, indent=2, ensure_ascii=False))
+        print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,72 @@
+document.getElementById('loadBtn').addEventListener('click', loadQuestion);
+let currentQuestion;
+let selected;
+
+function loadQuestion() {
+  const bank = document.getElementById('bankSelect').value;
+  if (!bank) return;
+  fetch(`/question?bank=${bank}`)
+    .then(r => r.json())
+    .then(renderQuestion);
+}
+
+function renderQuestion(q) {
+  currentQuestion = q;
+  selected = null;
+  document.getElementById('questionArea').style.display = 'block';
+  document.getElementById('qTitle').innerHTML = q.title || '';
+  document.getElementById('qText').textContent = q.text || '';
+  const img = document.getElementById('qImg');
+  if (q.resource_image) { img.src = q.resource_image; img.style.display='block'; } else { img.style.display='none'; }
+  const options = document.getElementById('answerOptions');
+  options.innerHTML = '';
+  document.getElementById('calcInput').style.display='none';
+  if (q.answers && q.answers.length) {
+    q.answers.forEach(a => {
+      const btn = document.createElement('button');
+      btn.textContent = a.text;
+      btn.onclick = () => { selected = a.answer_number; };
+      options.appendChild(btn);
+    });
+  } else {
+    document.getElementById('calcInput').style.display = 'block';
+  }
+  document.getElementById('feedback').textContent = '';
+  document.getElementById('explanation').style.display = 'none';
+}
+
+document.getElementById('checkBtn').onclick = function() {
+  if (!currentQuestion) return;
+  let correct = false;
+  if (currentQuestion.answers && currentQuestion.answers.length) {
+    correct = selected == currentQuestion.correct_answer_number;
+  } else {
+    const value = document.getElementById('calcInput').value.trim();
+    correct = value === (currentQuestion.correct_answer || '');
+  }
+  document.getElementById('feedback').textContent = correct ? 'Correct!' : 'Incorrect';
+  updateStats(currentQuestion.id, correct);
+};
+
+document.getElementById('revealBtn').onclick = function() {
+  if (!currentQuestion) return;
+  const ex = document.getElementById('explanation');
+  ex.textContent = currentQuestion.why || 'No explanation';
+  ex.style.display = 'block';
+};
+
+document.getElementById('saveBtn').onclick = function() {
+  if (!currentQuestion) return;
+  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
+  if (!data[currentQuestion.id]) data[currentQuestion.id] = {right:0, wrong:0, saved:false};
+  data[currentQuestion.id].saved = !data[currentQuestion.id].saved;
+  localStorage.setItem('questionStats', JSON.stringify(data));
+  alert(data[currentQuestion.id].saved ? 'Saved!' : 'Removed!');
+};
+
+function updateStats(id, correct) {
+  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
+  if (!data[id]) data[id] = {right:0, wrong:0, saved:false};
+  if (correct) data[id].right++; else data[id].wrong++;
+  localStorage.setItem('questionStats', JSON.stringify(data));
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; margin: 20px; }
+#answerOptions button { display: block; margin: 5px 0; }
+#feedback { margin-top: 10px; font-weight: bold; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Question Bank</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <h1>Question Bank</h1>
+  <label for="bankSelect">Select Bank:</label>
+  <select id="bankSelect">
+    <option value="">-- Choose --</option>
+    {% for bank in banks %}
+      <option value="{{ bank }}">{{ bank }}</option>
+    {% endfor %}
+  </select>
+  <button id="loadBtn">Load Question</button>
+
+  <div id="questionArea" style="display:none;">
+    <h2 id="qTitle"></h2>
+    <p id="qText"></p>
+    <img id="qImg" style="max-width:400px;display:none;">
+    <div id="answerOptions"></div>
+    <input type="text" id="calcInput" style="display:none;">
+    <button id="checkBtn">Check</button>
+    <button id="revealBtn">Reveal</button>
+    <button id="saveBtn">Save for review</button>
+    <div id="feedback"></div>
+    <div id="explanation" style="display:none;"></div>
+  </div>
+
+  <script src="{{ url_for('static', filename='main.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add ignore rules for intermediate output
- clean datasets to remove odd characters
- implement minimal Flask webapp with JS UI
- include requirements for running the example

## Testing
- `python3 scripts/clean_questions.py`
- `pip install -q Flask Unidecode`
- `python3 app.py` (fails without manually killing, but server starts)

------
https://chatgpt.com/codex/tasks/task_e_68895892ead0832ba174672cef9722db