### PR TITLE
Display unit next to calculation input

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -20,7 +20,10 @@ function renderQuestion(q) {
   if (q.resource_image) { img.src = q.resource_image; img.style.display='block'; } else { img.style.display='none'; }
   const options = document.getElementById('answerOptions');
   options.innerHTML = '';
-  document.getElementById('calcInput').style.display='none';
+  const calcInput = document.getElementById('calcInput');
+  const answerUnit = document.getElementById('answerUnit');
+  calcInput.style.display = 'none';
+  answerUnit.style.display = 'none';
   if (q.answers && q.answers.length) {
     q.answers.forEach(a => {
       const btn = document.createElement('button');
@@ -29,7 +32,13 @@ function renderQuestion(q) {
       options.appendChild(btn);
     });
   } else {
-    document.getElementById('calcInput').style.display = 'block';
+    calcInput.style.display = 'block';
+    if (q.answer_unit) {
+      answerUnit.textContent = q.answer_unit;
+      answerUnit.style.display = 'inline';
+    } else {
+      answerUnit.style.display = 'none';
+    }
   }
   const feedback = document.getElementById('feedback');
   feedback.textContent = '';

--- a/static/styles.css
+++ b/static/styles.css
@@ -64,6 +64,16 @@ button:hover {
   display: none;
 }
 
+#calcInput,
+#answerUnit {
+  vertical-align: middle;
+}
+
+#answerUnit {
+  display: none;
+  margin-left: 4px;
+}
+
 #explanation {
   display: none;
   margin-top: 10px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
       <p id="qText"></p>
       <img id="qImg" alt="Question image">
       <div id="answerOptions"></div>
-      <input type="text" id="calcInput">
+      <input type="text" id="calcInput"><span id="answerUnit"></span>
       <div class="button-row">
         <button id="checkBtn">Check</button>
         <button id="revealBtn">Reveal</button>


### PR DESCRIPTION
## Summary
- add a new `answerUnit` span next to the numerical input box
- show/hide the unit in the question renderer
- style the unit label so it aligns with the input field

## Testing
- `python -m py_compile app.py scripts/clean_questions.py`


------
https://chatgpt.com/codex/tasks/task_e_6889ec263808832b9fb6b271cbeb3336