### PR TITLE
Highlight selected answers

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -19,13 +19,18 @@ function renderQuestion(q) {
   const img = document.getElementById('qImg');
   if (q.resource_image) { img.src = q.resource_image; img.style.display='block'; } else { img.style.display='none'; }
   const options = document.getElementById('answerOptions');
+  options.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
   options.innerHTML = '';
   document.getElementById('calcInput').style.display='none';
   if (q.answers && q.answers.length) {
     q.answers.forEach(a => {
       const btn = document.createElement('button');
       btn.textContent = a.text;
-      btn.onclick = () => { selected = a.answer_number; };
+      btn.onclick = () => {
+        options.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
+        btn.classList.add('selected');
+        selected = a.answer_number;
+      };
       options.appendChild(btn);
     });
   } else {

--- a/static/styles.css
+++ b/static/styles.css
@@ -81,3 +81,8 @@ button:hover {
 .incorrect {
   color: #c62828;
 }
+
+.selected {
+  background-color: #ffe082;
+  color: #000;
+}


### PR DESCRIPTION
## Summary
- add `.selected` style for active answer buttons
- apply `.selected` on click in `main.js`
- clear highlight when rendering a new question

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889ec2a0980832b96ffc799e682211a