### PR TITLE
Display correct answer on reveal

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -35,6 +35,8 @@ function renderQuestion(q) {
   feedback.textContent = '';
   feedback.className = '';
   document.getElementById('explanation').style.display = 'none';
+  const ans = document.getElementById('answer');
+  if (ans) { ans.style.display = 'none'; ans.textContent = ''; }
 }
 
 document.getElementById('checkBtn').onclick = function() {
@@ -54,6 +56,19 @@ document.getElementById('checkBtn').onclick = function() {
 
 document.getElementById('revealBtn').onclick = function() {
   if (!currentQuestion) return;
+  const ansEl = document.getElementById('answer');
+  if (ansEl) {
+    let ansText = '';
+    if (currentQuestion.answers && currentQuestion.answers.length) {
+      const obj = currentQuestion.answers.find(a => a.answer_number == currentQuestion.correct_answer_number);
+      ansText = obj ? obj.text : '';
+    } else {
+      ansText = currentQuestion.correct_answer || '';
+      if (currentQuestion.answer_unit) ansText += ' ' + currentQuestion.answer_unit;
+    }
+    ansEl.textContent = ansText ? `Answer: ${ansText}` : 'Answer unavailable';
+    ansEl.style.display = 'block';
+  }
   const ex = document.getElementById('explanation');
   ex.textContent = currentQuestion.why || 'No explanation';
   ex.style.display = 'block';

--- a/static/styles.css
+++ b/static/styles.css
@@ -64,6 +64,12 @@ button:hover {
   display: none;
 }
 
+#answer {
+  display: none;
+  margin-top: 10px;
+  font-weight: bold;
+}
+
 #explanation {
   display: none;
   margin-top: 10px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,7 @@
         <button id="saveBtn">Save for review</button>
       </div>
       <div id="feedback"></div>
+      <div id="answer"></div>
       <div id="explanation"></div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show the correct answer text when the user reveals the explanation
- hide previous answers when loading a new question
- add area in HTML for the answer and accompanying styles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889ec2e4f34832ba3db2c5f14867104