### PR TITLE
Improve question rendering

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -15,7 +15,12 @@ function renderQuestion(q) {
   selected = null;
   document.getElementById('questionArea').style.display = 'block';
   document.getElementById('qTitle').innerHTML = q.title || '';
-  document.getElementById('qText').textContent = q.text || '';
+  const text = (q.text || '')
+    .replace(/\u2028/g, '\n')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\u200b/g, '');
+  document.getElementById('qText').innerHTML =
+    DOMPurify.sanitize(marked.parse(text));
   const img = document.getElementById('qImg');
   if (q.resource_image) { img.src = q.resource_image; img.style.display='block'; } else { img.style.display='none'; }
   const options = document.getElementById('answerOptions');
@@ -69,7 +74,11 @@ document.getElementById('checkBtn').onclick = function() {
 document.getElementById('revealBtn').onclick = function() {
   if (!currentQuestion) return;
   const ex = document.getElementById('explanation');
-  ex.textContent = currentQuestion.why || 'No explanation';
+  const why = (currentQuestion.why || '')
+    .replace(/\u2028/g, '\n')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\u200b/g, '');
+  ex.innerHTML = DOMPurify.sanitize(marked.parse(why || 'No explanation'));
   ex.style.display = 'block';
 };
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,5 +1,5 @@
 body {
-  font-family: 'Nunito', Arial, sans-serif;
+  font-family: 'Nunito', 'Noto Color Emoji', Arial, sans-serif;
   margin: 20px;
   background-color: #f4f6f8;
   color: #333;
@@ -38,6 +38,10 @@ button:hover {
   border-radius: 5px;
   background-color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+#qText {
+  white-space: pre-line;
 }
 
 #qImg {

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@2.3.10/dist/purify.min.js"></script>
   <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Marked and DOMPurify in the template
- parse question text/explanation as Markdown
- strip odd unicode characters before rendering
- display question text with preserved line breaks
- add emoji fallback font

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6889eff664ec832bb88749c66bdc5d4a