### PR TITLE
Add practice launch page replicating exam loader

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,18 @@ def index():
     return render_template("index.html", banks=sorted(BANKS))
 
 
+@app.route("/launch.html")
+def launch():
+    """Serve a simple launch page with an embedded practice interface."""
+    return render_template("launch.html")
+
+
+@app.route("/htmlDelivery/index.html")
+def html_delivery():
+    """Alias path used by the launch page for the practice interface."""
+    return render_template("index.html", banks=sorted(BANKS))
+
+
 @app.route("/question")
 def question():
     bank = request.args.get("bank")

--- a/static/main.js
+++ b/static/main.js
@@ -2,6 +2,16 @@ document.getElementById('loadBtn').addEventListener('click', loadQuestion);
 let currentQuestion;
 let selected;
 
+// Adjust layout when loaded in standalone mode
+document.addEventListener('DOMContentLoaded', function() {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('isStandAlone') === 'true') {
+    document.body.classList.add('standalone');
+    const container = document.querySelector('.container');
+    if (container) container.classList.add('standalone');
+  }
+});
+
 function loadQuestion() {
   const bank = document.getElementById('bankSelect').value;
   if (!bank) return;

--- a/static/styles.css
+++ b/static/styles.css
@@ -6,9 +6,18 @@ body {
   line-height: 1.6;
 }
 
+body.standalone {
+  margin: 0;
+}
+
 .container {
   max-width: 800px;
   margin: 0 auto;
+}
+
+.container.standalone {
+  max-width: none;
+  margin: 0;
 }
 
 #bankSelect,

--- a/templates/launch.html
+++ b/templates/launch.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Launch Practice</title>
+  <style>
+    .delivery-iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <iframe src="/htmlDelivery/index.html?isStandAlone=true&amp;keycode=TEST1234#keycode" class="delivery-iframe" frameborder="0"></iframe>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal `launch.html` replicating webarchive loader
- alias `/htmlDelivery/index.html` route for embedding
- adjust JS/CSS to support standalone view

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6889f4d6a7b8832ba18be0b8f79189fc