### PR TITLE
Add practice layout page

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,12 @@ def launch():
     return render_template("launch.html")
 
 
+@app.route("/practice")
+def practice_page():
+    """Simple static page replicating the exam practice layout."""
+    return render_template("practice.html")
+
+
 @app.route("/htmlDelivery/index.html")
 def html_delivery():
     """Alias path used by the launch page for the practice interface."""

--- a/static/practice.css
+++ b/static/practice.css
@@ -1,0 +1,140 @@
+body {
+  margin: 0;
+  font-family: 'Nunito', Arial, sans-serif;
+  background: #f9fbfc;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  background: #002b54;
+  color: #fff;
+}
+
+.progress {
+  flex: 1;
+  height: 10px;
+  background: #ccc;
+  margin: 0 20px;
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.progress .bar {
+  height: 100%;
+  background: #0095ff;
+  width: 0%;
+}
+
+.finish-btn {
+  background: #f6c71a;
+  color: #000;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-right: 10px;
+}
+
+.main {
+  display: flex;
+  height: calc(100vh - 120px);
+}
+
+.sidebar {
+  width: 120px;
+  padding: 20px;
+  background: #f0f2f5;
+  box-sizing: border-box;
+}
+
+.nav {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.nav li {
+  width: 40px;
+  height: 40px;
+  line-height: 40px;
+  text-align: center;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+}
+
+.nav li.active {
+  background: #007bff;
+  color: #fff;
+}
+
+.question-area {
+  flex: 1;
+  padding: 20px;
+  background: #fff;
+  overflow: auto;
+}
+
+.dose-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+.dose-table th,
+.dose-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+
+.prompt {
+  margin-top: 15px;
+  font-weight: bold;
+}
+
+.calculator {
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.calculator input {
+  width: 80px;
+  padding: 4px;
+  margin-left: 8px;
+}
+
+.unit {
+  margin-left: 4px;
+}
+
+.footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  background: #e5e9f0;
+}
+
+.nav-btns button {
+  margin-left: 10px;
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+}
+
+.next-btn {
+  background: #007bff;
+  color: #fff;
+}

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Practice Test</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap">
+  <link rel="stylesheet" href="{{ url_for('static', filename='practice.css') }}">
+</head>
+<body>
+  <header class="header">
+    <span class="test-title">Test: 2025 example questions Part 1</span>
+    <div class="progress"><div class="bar" style="width:0%"></div></div>
+    <div class="header-right">
+      <button class="finish-btn">Finish Test</button>
+      <span class="candidate">Candidate Name</span>
+    </div>
+  </header>
+
+  <div class="main">
+    <aside class="sidebar">
+      <ul class="nav">
+        {% for n in range(1,16) %}
+        <li class="{% if n==1 %}active{% endif %}">{{ n }}</li>
+        {% endfor %}
+      </ul>
+    </aside>
+
+    <section class="question-area">
+      <p class="scenario">A mother brings her child to the pharmacy looking for paracetamol. The following dosing schedule is provided.</p>
+      <table class="dose-table">
+        <tr><th>Age</th><th>Dose</th><th>Frequency</th></tr>
+        <tr><td>6–12 years</td><td>500 mg</td><td>Up to four times daily</td></tr>
+      </table>
+      <p class="prompt"><strong>How many tablets should be supplied for a 5‑day course?</strong></p>
+      <div class="calculator">
+        <span class="icon">&#128425;</span>
+        <label>Basic Calculator</label>
+        <input type="number">
+        <span class="unit">tablet(s)</span>
+      </div>
+    </section>
+  </div>
+
+  <footer class="footer">
+    <span class="settings">&#9881;</span>
+    <button class="close-btn">Close all open tools</button>
+    <div class="nav-btns">
+      <button class="back-btn">Back</button>
+      <button class="next-btn">Next ❯</button>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `practice.html` template replicating exam-style layout
- add `practice.css` for layout styling
- add `/practice` route to `app.py`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6889fa26649c832b9ad80cc475fe1f64