### PR TITLE
Add practice start options

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,4 +1,6 @@
 document.getElementById('loadBtn').addEventListener('click', loadQuestion);
+const practiceBtn = document.getElementById('practiceBtn');
+if (practiceBtn) practiceBtn.addEventListener('click', startPractice);
 let currentQuestion;
 let selected;
 
@@ -18,6 +20,20 @@ function loadQuestion() {
   fetch(`/question?bank=${bank}`)
     .then(r => r.json())
     .then(renderQuestion);
+}
+
+function startPractice() {
+  const bank = document.getElementById('bankSelect').value;
+  const num = parseInt(document.getElementById('numInput').value, 10);
+  if (!bank) {
+    alert('Please select a bank');
+    return;
+  }
+  if (!num || num <= 0) {
+    alert('Please enter a positive number of questions');
+    return;
+  }
+  window.location.href = `/practice?bank=${encodeURIComponent(bank)}&num=${num}`;
 }
 
 function renderQuestion(q) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,12 @@
         <option value="{{ bank }}">{{ bank }}</option>
       {% endfor %}
     </select>
-    <button id="loadBtn">Load Question</button>
+    <label for="numInput">Number of questions:</label>
+    <input type="number" id="numInput" value="1" min="1">
+    <div class="button-row">
+      <button id="loadBtn">Load Question</button>
+      <button id="practiceBtn">Start Practice</button>
+    </div>
 
     <div id="questionArea">
       <h2 id="qTitle"></h2>


### PR DESCRIPTION
## Summary
- add "Number of questions" input and new button on index page
- allow redirecting to `/practice` via new startPractice handler with validation

## Testing
- `python -m py_compile app.py scripts/clean_questions.py`

------
https://chatgpt.com/codex/tasks/task_e_688a09e12c7c832b85f363a7b35da40d