### PR TITLE
Fix question title injection

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -14,12 +14,12 @@ function renderQuestion(q) {
   currentQuestion = q;
   selected = null;
   document.getElementById('questionArea').style.display = 'block';
-  document.getElementById('qTitle').innerHTML = q.title || '';
+  document.getElementById('qTitle').textContent = q.title || '';
   document.getElementById('qText').textContent = q.text || '';
   const img = document.getElementById('qImg');
   if (q.resource_image) { img.src = q.resource_image; img.style.display='block'; } else { img.style.display='none'; }
   const options = document.getElementById('answerOptions');
-  options.innerHTML = '';
+  options.textContent = '';
   document.getElementById('calcInput').style.display='none';
   if (q.answers && q.answers.length) {
     q.answers.forEach(a => {


### PR DESCRIPTION
## Summary
- prevent HTML injection in the question title
- clear answer options using `textContent`

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68895c395164832b9e0f2c6d315a48b6