### PR TITLE
Replace innerHTML with textContent where HTML isn't expected

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -40,7 +40,7 @@ function renderQuestion(q) {
   currentQuestion = q;
   selected = null;
   document.getElementById('questionArea').style.display = 'block';
-  document.getElementById('qTitle').innerHTML = q.title || '';
+  document.getElementById('qTitle').textContent = q.title || '';
   const text = (q.text || '')
     .replace(/\u2028/g, '\n')
     .replace(/\u00a0/g, ' ')
@@ -51,7 +51,7 @@ function renderQuestion(q) {
   if (q.resource_image) { img.src = q.resource_image; img.style.display='block'; } else { img.style.display='none'; }
   const options = document.getElementById('answerOptions');
   options.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
-  options.innerHTML = '';
+  options.textContent = '';
   const calcInput = document.getElementById('calcInput');
   const answerUnit = document.getElementById('answerUnit');
   calcInput.style.display = 'none';

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -48,7 +48,7 @@
 
     function initNav() {
       const nav = document.querySelector('.nav');
-      nav.innerHTML = '';
+      nav.textContent = '';
       questions.forEach((q,i) => {
         const li = document.createElement('li');
         li.textContent = i+1;
@@ -76,7 +76,7 @@
       const calc = document.querySelector('.calculator');
       const input = calc.querySelector('input');
       const unit = calc.querySelector('.unit');
-      opts.innerHTML = '';
+      opts.textContent = '';
       if(q.answers && q.answers.length){
         calc.style.display = 'none';
         q.answers.forEach(a => {


### PR DESCRIPTION
## Summary
- avoid setting raw HTML for question titles and option lists
- clear practice page nav/option lists without innerHTML

## Testing
- `python3 -m py_compile app.py scripts/clean_questions.py Burp/checkquestions.py Burp/grabquetions.py`

------
https://chatgpt.com/codex/tasks/task_e_688a10bdd9d4832b8088567e641099b7