### PR TITLE
Fix sidebar scrolling

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -48,6 +48,8 @@ body {
   padding: 20px;
   background: #f0f2f5;
   box-sizing: border-box;
+  height: 100%;
+  overflow-y: auto;
 }
 
 .nav {


### PR DESCRIPTION
## Summary
- keep the sidebar the full height of the main section
- enable vertical scrolling on the sidebar so navigation never overflows

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688a185e67f0832bb50292d784c46c32