### PR TITLE
Add flagging support in practice mode

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -57,6 +57,7 @@ body {
 }
 
 .nav li {
+  position: relative;
   width: 40px;
   height: 40px;
   line-height: 40px;
@@ -66,6 +67,19 @@ body {
   border: 1px solid #ccc;
   background: #fff;
   cursor: pointer;
+}
+
+.nav li .flag-icon {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.nav li.flagged {
+  background: #fff8dc;
+  border-color: #f6c71a;
 }
 
 .nav li.active {

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -45,6 +45,11 @@
   <script>
     const questions = {{ questions|tojson|safe }};
     let index = 0;
+    let flags = JSON.parse(localStorage.getItem('flags') || '{}');
+
+    function saveFlags(){
+      localStorage.setItem('flags', JSON.stringify(flags));
+    }
 
     function initNav() {
       const nav = document.querySelector('.nav');
@@ -52,7 +57,18 @@
       questions.forEach((q,i) => {
         const li = document.createElement('li');
         li.textContent = i+1;
+        const flag = document.createElement('span');
+        flag.className = 'flag-icon';
+        flag.textContent = '\u2691';
+        flag.onclick = (e) => {
+          e.stopPropagation();
+          flags[i] = !flags[i];
+          li.classList.toggle('flagged', flags[i]);
+          saveFlags();
+        };
+        li.appendChild(flag);
         if(i===0) li.classList.add('active');
+        li.classList.toggle('flagged', flags[i]);
         li.onclick = () => { index = i; renderQuestion(); };
         nav.appendChild(li);
       });
@@ -66,6 +82,7 @@
     function updateNav() {
       document.querySelectorAll('.nav li').forEach((li,i) => {
         li.classList.toggle('active', i === index);
+        li.classList.toggle('flagged', flags[i]);
       });
     }
 


### PR DESCRIPTION
## Summary
- allow users to flag questions
- persist flag state in `localStorage`
- show flagged status with new styles

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688a1862dbe8832b89def62919812cb3