### PR TITLE
Improve practice option buttons

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -80,6 +80,14 @@ body {
   overflow: auto;
 }
 
+.options button {
+  display: block;
+  width: 100%;
+  padding: 0.4em 0.8em;
+  margin: 5px 0;
+  text-align: left;
+}
+
 .dose-table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- add vertical button styles for practice page options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a186d2cb0832ba48c53cda732b0ed