### PR TITLE
Add question stats lookup form

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -143,3 +143,18 @@ function updateStats(id, correct) {
   if (correct) data[id].right++; else data[id].wrong++;
   localStorage.setItem('questionStats', JSON.stringify(data));
 }
+
+const statsForm = document.getElementById('statsForm');
+if (statsForm) {
+  statsForm.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const id = document.getElementById('statsId').value.trim();
+    if (!id) return;
+    const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
+    const stats = data[id] || {right:0, wrong:0, saved:false};
+    const res = document.getElementById('statsResult');
+    if (res) {
+      res.textContent = `Right: ${stats.right}, Wrong: ${stats.wrong}, Saved: ${stats.saved ? 'Yes' : 'No'}`;
+    }
+  });
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -115,3 +115,11 @@ button:hover {
   background-color: #ffe082;
   color: #000;
 }
+
+#statsArea {
+  margin-top: 20px;
+  padding: 15px;
+  border-radius: 5px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,22 +24,32 @@
       <button id="practiceBtn">Start Practice</button>
     </div>
 
-    <div id="questionArea">
-      <h2 id="qTitle"></h2>
-      <p id="qText"></p>
-      <img id="qImg" alt="Question image">
-      <div id="answerOptions"></div>
-      <input type="text" id="calcInput"><span id="answerUnit"></span>
-      <div class="button-row">
-        <button id="checkBtn">Check</button>
-        <button id="revealBtn">Reveal</button>
-        <button id="saveBtn">Save for review</button>
+      <div id="questionArea">
+        <h2 id="qTitle"></h2>
+        <p id="qText"></p>
+        <img id="qImg" alt="Question image">
+        <div id="answerOptions"></div>
+        <input type="text" id="calcInput"><span id="answerUnit"></span>
+        <div class="button-row">
+          <button id="checkBtn">Check</button>
+          <button id="revealBtn">Reveal</button>
+          <button id="saveBtn">Save for review</button>
+        </div>
+        <div id="feedback"></div>
+        <div id="answer"></div>
+        <div id="explanation"></div>
       </div>
-      <div id="feedback"></div>
-      <div id="answer"></div>
-      <div id="explanation"></div>
+
+      <div id="statsArea">
+        <h2>Check Question Stats</h2>
+        <form id="statsForm">
+          <label for="statsId">Question ID:</label>
+          <input type="text" id="statsId" required>
+          <button type="submit">View</button>
+        </form>
+        <div id="statsResult"></div>
+      </div>
     </div>
-  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@2.3.10/dist/purify.min.js"></script>


### PR DESCRIPTION
## Summary
- add ability to look up saved question stats
- implement stats form in **index.html** and handle logic in **main.js**
- style stats area

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a187c2200832b80abc75c3ad24d36