### PR TITLE
Add finish test handler

### DIFF
--- a/templates/practice.html
+++ b/templates/practice.html
@@ -105,6 +105,13 @@
       initNav();
       renderQuestion();
     });
+
+    document.querySelector('.finish-btn').onclick = () => {
+      if (confirm('Are you sure you want to finish the test?')) {
+        const completed = index + 1;
+        alert(`Test complete! You viewed ${completed} of ${questions.length} questions.`);
+      }
+    };
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add click handler for finish button on practice page
- confirm with user before ending practice
- show alert summarizing completion

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a18711728832b96475d8c34dd59d0