### PR TITLE
Add question flagging to practice page

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -68,11 +68,33 @@ body {
   border: 1px solid #ccc;
   background: #fff;
   cursor: pointer;
+  position: relative;
 }
 
 .nav li.active {
   background: #007bff;
   color: #fff;
+}
+
+.nav li.flagged {
+  background: #fff3cd;
+  border-color: #ff9800;
+}
+
+.nav li.flagged .flag-btn {
+  color: #d32f2f;
+}
+
+.flag-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
 }
 
 .question-area {

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -52,13 +52,28 @@
     function initNav() {
       const nav = document.querySelector('.nav');
       nav.textContent = '';
+      const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
       questions.forEach((q,i) => {
         const li = document.createElement('li');
-        li.textContent = i+1;
+        li.innerHTML = `${i+1}<button class="flag-btn" title="Flag">\u2691</button>`;
         if(i===0) li.classList.add('active');
+        if (data[q.id] && data[q.id].saved) li.classList.add('flagged');
+        const flag = li.querySelector('.flag-btn');
+        flag.onclick = (e) => {
+          e.stopPropagation();
+          toggleFlag(q.id, li);
+        };
         li.onclick = () => { index = i; renderQuestion(); };
         nav.appendChild(li);
       });
+    }
+
+    function toggleFlag(id, li) {
+      const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
+      if (!data[id]) data[id] = {right:0, wrong:0, saved:false};
+      data[id].saved = !data[id].saved;
+      localStorage.setItem('questionStats', JSON.stringify(data));
+      li.classList.toggle('flagged', data[id].saved);
     }
 
     function updateProgress() {
@@ -67,8 +82,12 @@
     }
 
     function updateNav() {
+      const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
       document.querySelectorAll('.nav li').forEach((li,i) => {
+        const q = questions[i];
         li.classList.toggle('active', i === index);
+        const flagged = data[q.id] && data[q.id].saved;
+        li.classList.toggle('flagged', flagged);
       });
     }
 


### PR DESCRIPTION
## Summary
- add flag buttons for navigation items in practice page
- persist flag state using localStorage
- highlight flagged questions with new styles

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a1d7941cc832bb6a0e93eac44c73d