### PR TITLE
Fix flag toggle with older browsers

### DIFF
--- a/templates/practice.html
+++ b/templates/practice.html
@@ -92,7 +92,11 @@
       if (!data[id]) data[id] = {right:0, wrong:0, saved:false};
       data[id].saved = !data[id].saved;
       localStorage.setItem('questionStats', JSON.stringify(data));
-      li.classList.toggle('flagged', data[id].saved);
+      if (data[id].saved) {
+        li.classList.add('flagged');
+      } else {
+        li.classList.remove('flagged');
+      }
     }
 
     function updateProgress() {
@@ -106,7 +110,11 @@
         const q = questions[i];
         li.classList.toggle('active', i === index);
         const flagged = data[q.id] && data[q.id].saved;
-        li.classList.toggle('flagged', flagged);
+        if (flagged) {
+          li.classList.add('flagged');
+        } else {
+          li.classList.remove('flagged');
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- avoid classList.toggle(force) for flag actions

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_688a2d41afb8832b9a9a5378290bf686