### PR TITLE
Improve question statistics UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,6 +77,18 @@ def question():
     return jsonify(q)
 
 
+@app.route("/bank_questions")
+def bank_questions():
+    """Return all questions for a given bank."""
+    bank = request.args.get("bank")
+    if bank not in BANKS:
+        return jsonify({"error": "unknown bank"}), 404
+    questions = []
+    for p in BANKS[bank]:
+        questions.extend(_load(p))
+    return jsonify(questions)
+
+
 if __name__ == "__main__":
     app.run(debug=True)
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -124,3 +124,20 @@ button:hover {
   background-color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+
+#statsTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+#statsTable th,
+#statsTable td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  text-align: left;
+}
+
+#statsQuestionArea {
+  margin-top: 15px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
     <label for="numInput">Number of questions:</label>
     <input type="number" id="numInput" value="1" min="1">
     <div class="button-row">
-      <button id="loadBtn">Load Question</button>
+      <button id="loadBtn">Load Random Question</button>
       <button id="practiceBtn">Start Practice</button>
     </div>
 
@@ -41,13 +41,34 @@
       </div>
 
       <div id="statsArea">
-        <h2>Check Question Stats</h2>
-        <form id="statsForm">
-          <label for="statsId">Question ID:</label>
-          <input type="text" id="statsId" required>
-          <button type="submit">View</button>
-        </form>
-        <div id="statsResult"></div>
+        <h2>Question Statistics</h2>
+        <label for="statsBankSelect">Select Bank:</label>
+        <select id="statsBankSelect">
+          <option value="">-- Choose --</option>
+          {% for bank in banks %}
+            <option value="{{ bank }}">{{ bank }}</option>
+          {% endfor %}
+        </select>
+        <button id="loadStatsBtn">Load Stats</button>
+        <table id="statsTable">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Attempts</th>
+              <th>Right</th>
+              <th>Wrong</th>
+              <th>View</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <div id="statsQuestionArea" style="display:none;">
+          <h3 id="sqTitle"></h3>
+          <p id="sqText"></p>
+          <button id="sqRevealBtn">Reveal Answer</button>
+          <div id="sqAnswer"></div>
+          <div id="sqExplanation"></div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- rename single question loader to **Load Random Question**
- add `/bank_questions` endpoint
- add stats bank selection, table output and question viewer

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688a2c9d3170832b9d898bfe9392b73a