### PR TITLE
Improve practice button sizing

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -107,9 +107,10 @@ body {
 .options button {
   display: block;
   width: 100%;
-  padding: 0.4em 0.8em;
+  padding: 0.6em 1em;
   margin: 5px 0;
   text-align: left;
+  font-size: 1.1rem;
 }
 
 .dose-table {


### PR DESCRIPTION
## Summary
- enlarge buttons in the practice page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a56a9a6a0832b9e1831b91b367b58