### PR TITLE
Implement stats question modal

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -179,19 +179,27 @@ function renderStats() {
 function showStatsQuestion(id) {
   const q = statsQuestions.find(x => String(x.id) === String(id));
   if (!q) return;
-  document.getElementById('statsQuestionArea').style.display = 'block';
+  const overlay = document.getElementById('statsModal');
+  overlay.style.display = 'flex';
   document.getElementById('sqTitle').textContent = q.title || '';
   const text = (q.text || '')
     .replace(/\u2028/g, '\n')
     .replace(/\u00a0/g, ' ')
     .replace(/\u200b/g, '');
   document.getElementById('sqText').innerHTML = DOMPurify.sanitize(marked.parse(text));
+  const img = document.getElementById('sqImg');
+  if (q.resource_image) { img.src = q.resource_image; img.style.display = 'block'; }
+  else { img.style.display = 'none'; }
   document.getElementById('sqAnswer').style.display = 'none';
   document.getElementById('sqExplanation').style.display = 'none';
   document.getElementById('sqAnswer').textContent = '';
   document.getElementById('sqExplanation').textContent = '';
   document.getElementById('sqRevealBtn').onclick = () => revealStatsQuestion(q);
 }
+
+document.getElementById('sqCloseBtn').onclick = function() {
+  document.getElementById('statsModal').style.display = 'none';
+};
 
 function revealStatsQuestion(q) {
   let answerText = '';

--- a/static/styles.css
+++ b/static/styles.css
@@ -162,6 +162,43 @@ button:hover {
   text-align: left;
 }
 
-#statsQuestionArea {
-  margin-top: 15px;
+/* Modal overlay for viewing statistics questions */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
 }
+
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 5px;
+  max-width: 90%;
+  max-height: 90%;
+  overflow-y: auto;
+  position: relative;
+}
+
+.modal-content .close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+#sqImg {
+  max-width: 100%;
+  height: auto;
+  display: none;
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,12 +62,17 @@
           </thead>
           <tbody></tbody>
         </table>
-        <div id="statsQuestionArea" style="display:none;">
-          <h3 id="sqTitle"></h3>
-          <p id="sqText"></p>
-          <button id="sqRevealBtn">Reveal Answer</button>
-          <div id="sqAnswer"></div>
-          <div id="sqExplanation"></div>
+        <!-- Modal for displaying a single stats question -->
+        <div id="statsModal" class="modal-overlay">
+          <div class="modal-content">
+            <button id="sqCloseBtn" class="close">&times;</button>
+            <h3 id="sqTitle"></h3>
+            <p id="sqText"></p>
+            <img id="sqImg" alt="Question image">
+            <button id="sqRevealBtn">Reveal Answer</button>
+            <div id="sqAnswer"></div>
+            <div id="sqExplanation"></div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- swap stats area for a modal in `index.html`
- style the stats modal overlay and image
- populate and control the modal in `main.js`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a8f602a90832bb02fe6171e314bf2