### PR TITLE
Fix stats modal styles and sort API output

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,6 +86,7 @@ def bank_questions():
     questions = []
     for p in BANKS[bank]:
         questions.extend(_load(p))
+    questions.sort(key=lambda q: q.get("id", 0))
     return jsonify(questions)
 
 

--- a/static/main.js
+++ b/static/main.js
@@ -158,7 +158,7 @@ function loadStats() {
   if (!bank) return;
   fetch(`/bank_questions?bank=${bank}`)
     .then(r => r.json())
-    .then(qs => { statsQuestions = qs; renderStats(); });
+    .then(qs => { statsQuestions = qs.sort((a,b) => (a.id||0) - (b.id||0)); renderStats(); });
 }
 
 function renderStats() {

--- a/static/styles.css
+++ b/static/styles.css
@@ -194,6 +194,7 @@ button:hover {
   border: none;
   font-size: 1.5rem;
   cursor: pointer;
+  color: #000;
 }
 
 #sqImg {


### PR DESCRIPTION
## Summary
- sort questions by ID in `/bank_questions`
- ensure stats questions are ordered client-side
- make stats modal close button visible

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a9263a3bc832b885509cac0f193f2