### PR TITLE
Fix question display order and remove unused button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -25,8 +25,8 @@
     </div>
 
       <div id="questionArea">
-        <h2 id="qTitle"></h2>
         <p id="qText"></p>
+        <h2 id="qTitle"></h2>
         <img id="qImg" alt="Question image">
         <div id="answerOptions" class="options"></div>
         <input type="text" id="calcInput"><span id="answerUnit"></span>
@@ -66,8 +66,8 @@
         <div id="statsModal" class="modal-overlay">
           <div class="modal-content">
             <button id="sqCloseBtn" class="close">&times;</button>
-            <h3 id="sqTitle"></h3>
             <p id="sqText"></p>
+            <h3 id="sqTitle"></h3>
             <img id="sqImg" alt="Question image">
             <button id="sqRevealBtn">Reveal Answer</button>
             <div id="sqAnswer"></div>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -24,6 +24,7 @@
     <section class="question-area">
       <h2 class="q-number"></h2>
       <p class="scenario"></p>
+      <p class="prompt"></p>
       <div class="options"></div>
       <div class="calculator" style="display:none">
         <span class="icon">&#128425;</span>
@@ -54,7 +55,6 @@
 
   <footer class="footer">
     <span class="settings">&#9881;</span>
-    <button class="close-btn">Close all open tools</button>
     <div class="nav-btns">
       <button class="back-btn">Back</button>
       <button class="next-btn">Next ❯</button>
@@ -123,7 +123,9 @@
       const q = questions[index];
       selected = null;
       document.querySelector('.q-number').textContent = `Question ${index + 1}`;
-      document.querySelector('.scenario').textContent = q.text || q.title || '';
+      document.querySelector('.scenario').textContent = q.text || '';
+      const qPrompt = document.querySelector('.prompt');
+      if(qPrompt) qPrompt.textContent = q.title || '';
       const opts = document.querySelector('.options');
       const calc = document.querySelector('.calculator');
       const input = calc.querySelector('input');


### PR DESCRIPTION
## Summary
- reorder question text before question title across pages
- add separate question prompt on practice page
- remove unused "Close all open tools" button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a94c07958832baac29ec92014ae1d