### PR TITLE
Add container wrapper to practice page

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -4,6 +4,11 @@ body {
   background: #f9fbfc;
 }
 
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
 .header {
   display: flex;
   align-items: center;

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='practice.css') }}">
 </head>
 <body>
+  <div class="container">
   <header class="header">
     <span class="test-title">Test: 2025 example questions Part 1</span>
     <div class="progress"><div class="bar" style="width:0%"></div></div>
@@ -61,6 +62,7 @@
       <button class="flag-current-btn">Flag</button>
     </div>
   </footer>
+  </div>
 
   <script>
     const questions = {{ questions|tojson|safe }};


### PR DESCRIPTION
## Summary
- wrap practice page content in a new `.container` div
- define `.container` rules in `practice.css`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a9910ef1c832b971f47ac293b6b8f