### PR TITLE
Fix bold cleanup in question cleaner

### DIFF
--- a/scripts/clean_questions.py
+++ b/scripts/clean_questions.py
@@ -19,6 +19,8 @@ def clean_text(text: str) -> str:
     text = unidecode(text)
     # Replace non-breaking spaces
     text = text.replace("\u00a0", " ")
+    if text.startswith('**') and text.endswith('**'):
+        text = text[2:-2].strip()
     # Collapse whitespace
     text = re.sub(r"\s+", " ", text)
     return text.strip()


### PR DESCRIPTION
## Summary
- strip leading and trailing `**` markers in `clean_text`
- regenerate cleaned files

## Testing
- `python scripts/clean_questions.py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688a990942b8832b844daf509c76122b