### PR TITLE
Hide nav flag button until question flagged

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -87,9 +87,11 @@ body {
 
 .nav li.flagged .flag-btn {
   color: #d32f2f;
+  display: inline;
 }
 
 .flag-btn {
+  display: none;
   position: absolute;
   top: 2px;
   right: 2px;


### PR DESCRIPTION
## Summary
- hide the sidebar flag button by default and only show it when a question is flagged

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688a99067bd0832b869efe3a69c34148