### PR TITLE
Refactor updateStats into shared module

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,3 +1,5 @@
+import { updateStats } from './question_renderer.js';
+
 document.getElementById('loadBtn').addEventListener('click', loadQuestion);
 const practiceBtn = document.getElementById('practiceBtn');
 if (practiceBtn) practiceBtn.addEventListener('click', startPractice);
@@ -141,13 +143,6 @@ document.getElementById('saveBtn').onclick = function() {
   localStorage.setItem('questionStats', JSON.stringify(data));
   alert(data[currentQuestion.id].saved ? 'Saved!' : 'Removed!');
 };
-
-function updateStats(id, correct) {
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
-  if (!data[id]) data[id] = {right:0, wrong:0, saved:false};
-  if (correct) data[id].right++; else data[id].wrong++;
-  localStorage.setItem('questionStats', JSON.stringify(data));
-}
 
 let statsQuestions = [];
 const loadStatsBtn = document.getElementById('loadStatsBtn');

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -1,0 +1,10 @@
+export function updateStats(id, correct) {
+  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
+  if (!data[id]) data[id] = { right: 0, wrong: 0, saved: false };
+  if (correct) {
+    data[id].right++;
+  } else {
+    data[id].wrong++;
+  }
+  localStorage.setItem('questionStats', JSON.stringify(data));
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,6 +79,6 @@
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@2.3.10/dist/purify.min.js"></script>
-  <script src="{{ url_for('static', filename='main.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -63,7 +63,9 @@
   </footer>
   </div>
 
-  <script>
+  <script type="module">
+    import { updateStats } from "{{ url_for('static', filename='question_renderer.js') }}";
+
     const questions = {{ questions|tojson|safe }};
     let index = 0;
     let selected = null;
@@ -210,13 +212,6 @@
       }
       updateProgress();
       updateNav();
-    }
-
-    function updateStats(id, correct) {
-      const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
-      if (!data[id]) data[id] = {right:0, wrong:0, saved:false};
-      if (correct) data[id].right++; else data[id].wrong++;
-      localStorage.setItem('questionStats', JSON.stringify(data));
     }
 
     function recordAnswer(){


### PR DESCRIPTION
## Summary
- create `question_renderer.js` with shared `updateStats`
- import the module into `main.js`
- use the module from the practice page
- load `main.js` as an ES module

## Testing
- `python -m py_compile app.py`
- `node --check static/question_renderer.js`


------
https://chatgpt.com/codex/tasks/task_e_688aa2d5d3d0832ba1b1d46e962edd77