### PR TITLE
Refactor question rendering

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -40,51 +40,27 @@ function renderQuestion(q) {
   currentQuestion = q;
   selected = null;
   document.getElementById('questionArea').style.display = 'block';
-  document.getElementById('qTitle').textContent = q.title || '';
-  const text = (q.text || '')
-    .replace(/\u2028/g, '\n')
-    .replace(/\u00a0/g, ' ')
-    .replace(/\u200b/g, '');
-  document.getElementById('qText').innerHTML =
-    DOMPurify.sanitize(marked.parse(text));
-  const img = document.getElementById('qImg');
-  if (q.resource_image) { img.src = q.resource_image; img.style.display='block'; } else { img.style.display='none'; }
+  const result = questionRenderer.renderQuestion(q, {
+    text: '#qText',
+    title: '#qTitle',
+    img: '#qImg',
+    options: '#answerOptions',
+    input: '#calcInput',
+    unit: '#answerUnit',
+    feedback: '#feedback',
+    answer: '#answer',
+    explanation: '#explanation',
+    showInput: true
+  });
   const options = document.getElementById('answerOptions');
-  options.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
-  options.textContent = '';
-  const calcInput = document.getElementById('calcInput');
-  const answerUnit = document.getElementById('answerUnit');
-  calcInput.style.display = 'none';
-  answerUnit.style.display = 'none';
   if (q.answers && q.answers.length) {
-    q.answers.forEach(a => {
-      const btn = document.createElement('button');
-      btn.textContent = a.text;
-      btn.dataset.num = a.answer_number;
+    result.buttons.forEach(btn => {
       btn.onclick = () => {
         options.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
         btn.classList.add('selected');
-        selected = a.answer_number;
+        selected = btn.dataset.num;
       };
-      options.appendChild(btn);
     });
-  } else {
-    calcInput.style.display = 'block';
-    if (q.answer_unit) {
-      answerUnit.textContent = q.answer_unit;
-      answerUnit.style.display = 'inline';
-    } else {
-      answerUnit.style.display = 'none';
-    }
-  }
-  const feedback = document.getElementById('feedback');
-  feedback.textContent = '';
-  feedback.className = '';
-  document.getElementById('explanation').style.display = 'none';
-  const ans = document.getElementById('answer');
-  if (ans) {
-    ans.textContent = '';
-    ans.style.display = 'none';
   }
 }
 
@@ -181,19 +157,14 @@ function showStatsQuestion(id) {
   if (!q) return;
   const overlay = document.getElementById('statsModal');
   overlay.style.display = 'flex';
-  document.getElementById('sqTitle').textContent = q.title || '';
-  const text = (q.text || '')
-    .replace(/\u2028/g, '\n')
-    .replace(/\u00a0/g, ' ')
-    .replace(/\u200b/g, '');
-  document.getElementById('sqText').innerHTML = DOMPurify.sanitize(marked.parse(text));
-  const img = document.getElementById('sqImg');
-  if (q.resource_image) { img.src = q.resource_image; img.style.display = 'block'; }
-  else { img.style.display = 'none'; }
-  document.getElementById('sqAnswer').style.display = 'none';
-  document.getElementById('sqExplanation').style.display = 'none';
-  document.getElementById('sqAnswer').textContent = '';
-  document.getElementById('sqExplanation').textContent = '';
+  questionRenderer.renderQuestion(q, {
+    text: '#sqText',
+    title: '#sqTitle',
+    img: '#sqImg',
+    answer: '#sqAnswer',
+    explanation: '#sqExplanation',
+    showInput: false
+  });
   const revealBtn = document.getElementById('sqRevealBtn');
   revealBtn.textContent = 'Reveal Answer';
   revealBtn.onclick = () => revealStatsQuestion(q);

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -1,0 +1,92 @@
+(function(global){
+  function sanitize(text){
+    text = (text || '').replace(/\u2028/g, '\n').replace(/\u00a0/g, ' ').replace(/\u200b/g, '');
+    if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
+      return DOMPurify.sanitize(marked.parse(text));
+    }
+    return text;
+  }
+
+  function renderQuestion(question, config){
+    config = config || {};
+    const get = sel => sel ? document.querySelector(sel) : null;
+
+    const textEl = get(config.text);
+    const titleEl = get(config.title);
+    const imgEl = get(config.img);
+    const optionsEl = get(config.options);
+    const inputEl = get(config.input);
+    const unitEl = get(config.unit);
+    const feedbackEl = get(config.feedback);
+    const answerEl = get(config.answer);
+    const explanationEl = get(config.explanation);
+    const showInput = config.showInput !== false;
+
+    if (titleEl) titleEl.textContent = question.title || '';
+    if (textEl) {
+      const txt = sanitize(question.text || '');
+      if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
+        textEl.innerHTML = txt;
+      } else {
+        textEl.textContent = txt;
+      }
+    }
+
+    if (imgEl) {
+      if (question.resource_image) {
+        imgEl.src = question.resource_image;
+        imgEl.style.display = 'block';
+      } else {
+        imgEl.style.display = 'none';
+      }
+    }
+
+    if (feedbackEl) {
+      feedbackEl.textContent = '';
+      feedbackEl.classList.remove('correct', 'incorrect');
+    }
+    if (answerEl) { answerEl.textContent = ''; answerEl.style.display = 'none'; }
+    if (explanationEl) { explanationEl.innerHTML = ''; explanationEl.style.display = 'none'; }
+
+    let buttons = [];
+    if (optionsEl) { optionsEl.textContent = ''; optionsEl.style.display = ''; }
+    if (inputEl) { inputEl.style.display = 'none'; }
+    if (unitEl) { unitEl.style.display = 'none'; }
+
+    if (showInput) {
+      if (question.answers && question.answers.length) {
+        if (optionsEl) {
+          question.answers.forEach(a => {
+            const btn = document.createElement('button');
+            btn.textContent = a.text;
+            btn.dataset.num = a.answer_number;
+            optionsEl.appendChild(btn);
+            buttons.push(btn);
+          });
+        }
+      } else {
+        if (optionsEl) optionsEl.style.display = 'none';
+        if (inputEl) {
+          inputEl.value = '';
+          inputEl.style.display = 'block';
+        }
+        if (unitEl) {
+          if (question.answer_unit) {
+            unitEl.textContent = question.answer_unit;
+            unitEl.style.display = 'inline';
+          } else {
+            unitEl.style.display = 'none';
+          }
+        }
+      }
+    } else {
+      if (optionsEl) optionsEl.style.display = 'none';
+      if (inputEl) inputEl.style.display = 'none';
+      if (unitEl) unitEl.style.display = 'none';
+    }
+
+    return {buttons, input: inputEl};
+  }
+
+  global.questionRenderer = { renderQuestion };
+})(this);

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,6 +79,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@2.3.10/dist/purify.min.js"></script>
+  <script src="{{ url_for('static', filename='question_renderer.js') }}"></script>
   <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -63,6 +63,7 @@
   </footer>
   </div>
 
+  <script src="{{ url_for('static', filename='question_renderer.js') }}"></script>
   <script>
     const questions = {{ questions|tojson|safe }};
     let index = 0;
@@ -129,9 +130,17 @@
       const q = questions[index];
       selected = null;
       document.querySelector('.q-number').textContent = `Question ${index + 1}`;
-      document.querySelector('.scenario').textContent = q.text || '';
-      const qPrompt = document.querySelector('.prompt');
-      if(qPrompt) qPrompt.textContent = q.title || '';
+      const result = questionRenderer.renderQuestion(q, {
+        text: '.scenario',
+        title: '.prompt',
+        options: '.options',
+        input: '.calculator input',
+        unit: '.calculator .unit',
+        feedback: '.feedback',
+        answer: '.correct-answer',
+        explanation: '.explanation',
+        showInput: true
+      });
       const opts = document.querySelector('.options');
       const calc = document.querySelector('.calculator');
       const input = calc.querySelector('input');
@@ -140,35 +149,25 @@
       const details = document.querySelector('.details');
       const corr = details.querySelector('.correct-answer');
       const expl = details.querySelector('.explanation');
-      feedback.textContent = '';
-      feedback.className = 'feedback';
-      details.style.display = 'none';
-      corr.textContent = '';
-      expl.textContent = '';
-      opts.textContent = '';
       if(q.answers && q.answers.length){
         calc.style.display = 'none';
-        q.answers.forEach(a => {
-          const btn = document.createElement('button');
-          btn.textContent = a.text;
-          btn.dataset.num = a.answer_number;
+        result.buttons.forEach(btn => {
           btn.onclick = () => {
             if(reviewing) return;
             opts.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
             btn.classList.add('selected');
-            selected = a.answer_number;
+            selected = btn.dataset.num;
           };
-          if(responses[index] && responses[index].answer == a.answer_number){
+          if(responses[index] && responses[index].answer == btn.dataset.num){
             btn.classList.add('selected');
-            selected = a.answer_number;
+            selected = btn.dataset.num;
           }
           if(reviewing){
             btn.disabled = true;
-            if(a.answer_number == q.correct_answer_number){
+            if(btn.dataset.num == q.correct_answer_number){
               btn.classList.add('correct');
             }
           }
-          opts.appendChild(btn);
         });
       } else {
         calc.style.display = 'block';


### PR DESCRIPTION
## Summary
- add reusable `question_renderer.js`
- use helper in index page via `main.js`
- reuse rendering for stats modal
- integrate helper into practice test page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688aa2d597e0832bbfd50bde74c6d887