### PR TITLE
Move updateStats into shared renderer

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -80,7 +80,7 @@ document.getElementById('checkBtn').onclick = function() {
   const feedback = document.getElementById('feedback');
   feedback.textContent = correct ? 'Correct!' : 'Incorrect';
   feedback.className = correct ? 'correct' : 'incorrect';
-  updateStats(currentQuestion.id, correct);
+  questionRenderer.updateStats(currentQuestion.id, correct);
 };
 
 document.getElementById('revealBtn').onclick = function() {
@@ -118,12 +118,6 @@ document.getElementById('saveBtn').onclick = function() {
   alert(data[currentQuestion.id].saved ? 'Saved!' : 'Removed!');
 };
 
-function updateStats(id, correct) {
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
-  if (!data[id]) data[id] = {right:0, wrong:0, saved:false};
-  if (correct) data[id].right++; else data[id].wrong++;
-  localStorage.setItem('questionStats', JSON.stringify(data));
-}
 
 let statsQuestions = [];
 const loadStatsBtn = document.getElementById('loadStatsBtn');

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -88,5 +88,12 @@
     return {buttons, input: inputEl};
   }
 
-  global.questionRenderer = { renderQuestion };
+  function updateStats(id, correct){
+    const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
+    if(!data[id]) data[id] = {right:0, wrong:0, saved:false};
+    if(correct) data[id].right++; else data[id].wrong++;
+    localStorage.setItem('questionStats', JSON.stringify(data));
+  }
+
+  global.questionRenderer = { renderQuestion, updateStats };
 })(this);

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -211,12 +211,6 @@
       updateNav();
     }
 
-    function updateStats(id, correct) {
-      const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
-      if (!data[id]) data[id] = {right:0, wrong:0, saved:false};
-      if (correct) data[id].right++; else data[id].wrong++;
-      localStorage.setItem('questionStats', JSON.stringify(data));
-    }
 
     function recordAnswer(){
       const q = questions[index];
@@ -275,7 +269,7 @@
       const fb = document.querySelector('.feedback');
       fb.textContent = correct ? 'Correct!' : 'Incorrect';
       fb.className = 'feedback ' + (correct ? 'correct' : 'incorrect');
-      updateStats(q.id, correct);
+      questionRenderer.updateStats(q.id, correct);
       recordAnswer();
     };
 


### PR DESCRIPTION
## Summary
- centralize updateStats helper inside `question_renderer.js`
- call `questionRenderer.updateStats` from `main.js` and practice page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa5fcd92c832ba427bcb17bfcf408