### PR TITLE
Switch to Node install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,18 @@ browser, storing your progress locally.
 
 ## Setup
 
-1. Create and activate a virtual environment (optional but recommended):
+1. Install the dependencies:
 
-   ```bash
-   python3 -m venv venv
-   source venv/bin/activate
-   ```
-
-2. Install the required dependencies:
-
-   ```bash
-   pip install -r requirements.txt
-   ```
+```bash
+npm install
+```
 
 ## Running the app
 
-Start the Flask development server by executing `app.py`:
+Run the server with Node:
 
 ```bash
-python app.py
+node server.js
 ```
 
 By default the server loads question files from the `cleaned/` folder if it exists, otherwise it uses `output/`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "question-bank",
+  "version": "1.0.0",
+  "description": "Question Bank app",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ejs": "^3.1.9"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-Flask>=3.0
-Unidecode>=1.3


### PR DESCRIPTION
## Summary
- add `package.json`
- replace Python setup details with Node install instructions
- remove obsolete `requirements.txt`

## Testing
- `npm install` *(fails: 403 Forbidden due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_688bc1993c64832b9839f6453f485a62