### PR TITLE
Switch to Node setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,24 @@ browser, storing your progress locally.
 
 ## Setup
 
-1. Create and activate a virtual environment (optional but recommended):
+1. Install Node dependencies:
 
-   ```bash
-   python3 -m venv venv
-   source venv/bin/activate
-   ```
-
-2. Install the required dependencies:
-
-   ```bash
-   pip install -r requirements.txt
-   ```
+```bash
+npm install
+```
 
 ## Running the app
 
-Start the Flask development server by executing `app.py`:
+Launch the server with:
 
 ```bash
-python app.py
+node server.js
 ```
 
 By default the server loads question files from the `cleaned/` folder if it exists, otherwise it uses `output/`.
 
 Open a browser to `http://localhost:5000/` to view the interface.
+
 
 ## Practice overview
 

--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "ejs": "^3.1.9"
+  }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-Flask>=3.0
-Unidecode>=1.3


### PR DESCRIPTION
## Summary
- remove Python requirements
- add Express and EJS deps
- update README for Node usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688bc2bccc50832bb06b4ab20ef9a507