### PR TITLE
Refactor sanitization helper

### DIFF
--- a/scripts/clean_questions.js
+++ b/scripts/clean_questions.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const { questionRenderer } = require('../static/question_renderer.js');
+const sanitize = questionRenderer.sanitize;
 
 const INPUT_DIR = path.join(__dirname, '..', 'question_banks');
 const OUTPUT_DIR = path.join(__dirname, '..', 'output');
@@ -46,10 +48,10 @@ function asciiNormalize(str) {
 
 function cleanText(text) {
   if (typeof text !== 'string') return text;
+  text = sanitize(text);
   text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   text = text.normalize('NFKC');
   text = asciiNormalize(text);
-  text = text.replace(/\u00a0/g, ' ');
   if (text.startsWith('**') && text.endsWith('**')) {
     text = text.slice(2, -2).trim();
   }

--- a/static/main.js
+++ b/static/main.js
@@ -111,11 +111,7 @@ document.getElementById('revealBtn').onclick = function() {
     ans.style.display = 'block';
   }
   const ex = document.getElementById('explanation');
-  const why = (currentQuestion.why || '')
-    .replace(/\u2028/g, '\n')
-    .replace(/\u00a0/g, ' ')
-    .replace(/\u200b/g, '');
-  ex.innerHTML = DOMPurify.sanitize(marked.parse(why || 'No explanation'));
+  ex.innerHTML = questionRenderer.sanitize(currentQuestion.why || 'No explanation');
   ex.style.display = 'block';
 };
 
@@ -209,11 +205,7 @@ function revealStatsQuestion(q) {
     if (q.answer_unit) answerText += ' ' + q.answer_unit;
   }
   ans.textContent = answerText ? `Answer: ${answerText}` : '';
-  const why = (q.why || '')
-    .replace(/\u2028/g, '\n')
-    .replace(/\u00a0/g, ' ')
-    .replace(/\u200b/g, '');
-  ex.innerHTML = DOMPurify.sanitize(marked.parse(why || 'No explanation'));
+  ex.innerHTML = questionRenderer.sanitize(q.why || 'No explanation');
   ans.style.display = 'block';
   ex.style.display = 'block';
   btn.textContent = 'Hide Answer';

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -95,5 +95,5 @@
     localStorage.setItem('questionStats', JSON.stringify(data));
   }
 
-  global.questionRenderer = { renderQuestion, updateStats };
+  global.questionRenderer = { renderQuestion, updateStats, sanitize };
 })(this);

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -272,13 +272,8 @@
           }
           corr.textContent = correctText ? `Correct answer: ${correctText}` : '';
         }
-        let expText = questions[index].why || '';
-        expText = expText.replace(/\u2028/g, '\n').replace(/\u00a0/g, ' ').replace(/\u200b/g, '');
-        if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
-          expl.innerHTML = DOMPurify.sanitize(marked.parse(expText));
-        } else {
-          expl.textContent = expText;
-        }
+        const expText = questionRenderer.sanitize(questions[index].why || '');
+        expl.innerHTML = expText;
         convertPdfLinks(expl);
         details.style.display = 'block';
       } else {


### PR DESCRIPTION
## Summary
- expose shared `sanitize` helper via `questionRenderer`
- reuse `questionRenderer.sanitize` across browser and Node scripts
- simplify HTML templates to rely on shared sanitization logic

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_688dd1bfdfc4832b8c0b35b244d65197