### PR TITLE
refactor: centralize answer evaluation

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -76,21 +76,13 @@ function renderQuestion(q) {
 
 document.getElementById('checkBtn').onclick = function() {
   if (!currentQuestion) return;
-  const options = document.getElementById('answerOptions');
-  let correct = false;
-  if (currentQuestion.answers && currentQuestion.answers.length) {
-    correct = selected == currentQuestion.correct_answer_number;
-    options.querySelectorAll('button').forEach(b => b.disabled = true);
-    const correctBtn = options.querySelector(`button[data-num='${currentQuestion.correct_answer_number}']`);
-    if (correctBtn) correctBtn.classList.add('correct');
-  } else {
-    const value = document.getElementById('calcInput').value.trim();
-    correct = value === (currentQuestion.correct_answer || '');
-  }
-  const feedback = document.getElementById('feedback');
-  feedback.textContent = correct ? 'Correct!' : 'Incorrect';
-  feedback.className = correct ? 'correct' : 'incorrect';
-  questionRenderer.updateStats(currentQuestion.id, correct);
+  const value = (currentQuestion.answers && currentQuestion.answers.length)
+    ? selected
+    : document.getElementById('calcInput').value.trim();
+  questionRenderer.evaluateAnswer(currentQuestion, value, {
+    options: '#answerOptions',
+    feedback: '#feedback'
+  });
 };
 
 document.getElementById('revealBtn').onclick = function() {

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -95,5 +95,42 @@
     localStorage.setItem('questionStats', JSON.stringify(data));
   }
 
-  global.questionRenderer = { renderQuestion, updateStats };
+  function evaluateAnswer(question, selected, config){
+    config = config || {};
+    const get = sel => {
+      if (!sel) return null;
+      return typeof sel === 'string' ? document.querySelector(sel) : sel;
+    };
+
+    const optionsEl = get(config.options);
+    const feedbackEl = get(config.feedback);
+    const inputEl = get(config.input); // currently unused but kept for future
+
+    let correct = false;
+    if (question.answers && question.answers.length){
+      correct = String(selected) === String(question.correct_answer_number);
+      if (optionsEl){
+        optionsEl.querySelectorAll('button').forEach(b => b.disabled = true);
+        const correctBtn = optionsEl.querySelector(`button[data-num='${question.correct_answer_number}']`);
+        if (correctBtn) correctBtn.classList.add('correct');
+      }
+    } else {
+      const value = (selected || '').trim();
+      correct = value === (question.correct_answer || '');
+      if (inputEl) {
+        // allow future behaviour like disabling input if needed
+      }
+    }
+
+    if (feedbackEl){
+      feedbackEl.textContent = correct ? 'Correct!' : 'Incorrect';
+      feedbackEl.classList.remove('correct', 'incorrect');
+      feedbackEl.classList.add(correct ? 'correct' : 'incorrect');
+    }
+
+    updateStats(question.id, correct);
+    return correct;
+  }
+
+  global.questionRenderer = { renderQuestion, evaluateAnswer, updateStats };
 })(this);

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -333,23 +333,14 @@
 
   document.querySelector('.check-btn').onclick = () => {
       const q = questions[index];
-      const opts = document.querySelector('.options');
-      const calc = document.querySelector('.calculator');
-      const input = calc.querySelector('input');
-      let correct = false;
-      if(q.answers && q.answers.length){
-        correct = selected == q.correct_answer_number;
-        opts.querySelectorAll('button').forEach(b => b.disabled = true);
-        const correctBtn = opts.querySelector(`button[data-num='${q.correct_answer_number}']`);
-        if(correctBtn) correctBtn.classList.add('correct');
-      } else {
-        const value = input.value.trim();
-        correct = value === (q.correct_answer || '');
-      }
-      const fb = document.querySelector('.feedback');
-      fb.textContent = correct ? 'Correct!' : 'Incorrect';
-      fb.className = 'feedback ' + (correct ? 'correct' : 'incorrect');
-      questionRenderer.updateStats(q.id, correct);
+      const input = document.querySelector('.calculator input');
+      const value = (q.answers && q.answers.length)
+        ? selected
+        : (input ? input.value.trim() : '');
+      questionRenderer.evaluateAnswer(q, value, {
+        options: '.options',
+        feedback: '.feedback'
+      });
       recordAnswer();
     };
 


### PR DESCRIPTION
## Summary
- add reusable `evaluateAnswer` in `question_renderer` to validate answers and show feedback
- use `evaluateAnswer` in main practice and single-question flows

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dd1c7454c832b8454f64bb9051c7b