### PR TITLE
Add questionRenderer revealAnswer helper and integrate

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -95,28 +95,10 @@ document.getElementById('checkBtn').onclick = function() {
 
 document.getElementById('revealBtn').onclick = function() {
   if (!currentQuestion) return;
-  let answerText = '';
-  if (currentQuestion.answers && currentQuestion.answers.length) {
-    const obj = currentQuestion.answers.find(a => a.answer_number == currentQuestion.correct_answer_number);
-    answerText = obj ? obj.text : '';
-  } else {
-    answerText = currentQuestion.correct_answer || '';
-    if (currentQuestion.answer_unit) {
-      answerText += ' ' + currentQuestion.answer_unit;
-    }
-  }
-  const ans = document.getElementById('answer');
-  if (ans) {
-    ans.textContent = answerText ? `Answer: ${answerText}` : '';
-    ans.style.display = 'block';
-  }
-  const ex = document.getElementById('explanation');
-  const why = (currentQuestion.why || '')
-    .replace(/\u2028/g, '\n')
-    .replace(/\u00a0/g, ' ')
-    .replace(/\u200b/g, '');
-  ex.innerHTML = DOMPurify.sanitize(marked.parse(why || 'No explanation'));
-  ex.style.display = 'block';
+  questionRenderer.revealAnswer(currentQuestion, {
+    answer: '#answer',
+    explanation: '#explanation'
+  });
 };
 
 document.getElementById('saveBtn').onclick = function() {
@@ -199,22 +181,9 @@ function revealStatsQuestion(q) {
     btn.textContent = 'Reveal Answer';
     return;
   }
-
-  let answerText = '';
-  if (q.answers && q.answers.length) {
-    const obj = q.answers.find(a => a.answer_number == q.correct_answer_number);
-    answerText = obj ? obj.text : '';
-  } else {
-    answerText = q.correct_answer || '';
-    if (q.answer_unit) answerText += ' ' + q.answer_unit;
-  }
-  ans.textContent = answerText ? `Answer: ${answerText}` : '';
-  const why = (q.why || '')
-    .replace(/\u2028/g, '\n')
-    .replace(/\u00a0/g, ' ')
-    .replace(/\u200b/g, '');
-  ex.innerHTML = DOMPurify.sanitize(marked.parse(why || 'No explanation'));
-  ans.style.display = 'block';
-  ex.style.display = 'block';
+  questionRenderer.revealAnswer(q, {
+    answer: '#sqAnswer',
+    explanation: '#sqExplanation'
+  });
   btn.textContent = 'Hide Answer';
 }

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -88,6 +88,43 @@
     return {buttons, input: inputEl};
   }
 
+  function revealAnswer(question, targets){
+    targets = targets || {};
+    const get = sel => sel ? (typeof sel === 'string' ? document.querySelector(sel) : sel) : null;
+    const answerEl = get(targets.answer);
+    const explanationEl = get(targets.explanation);
+    const prefix = targets.prefix || 'Answer';
+
+    let answerText = '';
+    if (question.answers && question.answers.length) {
+      const obj = question.answers.find(a => a.answer_number == question.correct_answer_number);
+      answerText = obj ? obj.text : '';
+    } else {
+      answerText = question.correct_answer || '';
+      if (question.answer_unit) {
+        answerText += ' ' + question.answer_unit;
+      }
+    }
+
+    if (answerEl) {
+      answerEl.textContent = answerText ? `${prefix}: ${answerText}` : '';
+      answerEl.style.display = 'block';
+    }
+
+    if (explanationEl) {
+      const why = (question.why || '')
+        .replace(/\u2028/g, '\n')
+        .replace(/\u00a0/g, ' ')
+        .replace(/\u200b/g, '');
+      if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
+        explanationEl.innerHTML = DOMPurify.sanitize(marked.parse(why || 'No explanation'));
+      } else {
+        explanationEl.textContent = why || 'No explanation';
+      }
+      explanationEl.style.display = 'block';
+    }
+  }
+
   function updateStats(id, correct){
     const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
     if(!data[id]) data[id] = {right:0, wrong:0, saved:false};
@@ -95,5 +132,5 @@
     localStorage.setItem('questionStats', JSON.stringify(data));
   }
 
-  global.questionRenderer = { renderQuestion, updateStats };
+  global.questionRenderer = { renderQuestion, revealAnswer, updateStats };
 })(this);

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -259,26 +259,15 @@
         if (responses[index]){
           fb.textContent = responses[index].correct ? 'Correct!' : 'Incorrect';
           fb.className = 'feedback ' + (responses[index].correct ? 'correct' : 'incorrect');
-          corr.textContent = responses[index].correctAnswer ? `Correct answer: ${responses[index].correctAnswer}` : '';
         } else {
           fb.textContent = 'Not answered';
           fb.className = 'feedback';
-          let correctText = '';
-          if(q.answers && q.answers.length){
-            const obj = q.answers.find(a => a.answer_number == q.correct_answer_number);
-            correctText = obj ? obj.text : '';
-          } else {
-            correctText = (q.correct_answer || '') + (q.answer_unit ? ` ${q.answer_unit}` : '');
-          }
-          corr.textContent = correctText ? `Correct answer: ${correctText}` : '';
         }
-        let expText = questions[index].why || '';
-        expText = expText.replace(/\u2028/g, '\n').replace(/\u00a0/g, ' ').replace(/\u200b/g, '');
-        if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
-          expl.innerHTML = DOMPurify.sanitize(marked.parse(expText));
-        } else {
-          expl.textContent = expText;
-        }
+        questionRenderer.revealAnswer(q, {
+          answer: corr,
+          explanation: expl,
+          prefix: 'Correct answer'
+        });
         convertPdfLinks(expl);
         details.style.display = 'block';
       } else {


### PR DESCRIPTION
## Summary
- Add `questionRenderer.revealAnswer` utility for consistent answer and explanation display.
- Refactor main interface and stats modal to use the new helper.
- Simplify practice review logic by using the helper with a configurable prefix.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dd1d9b0d0832b8ba88f21123d4a10