### PR TITLE
Remove duplicate arrow replacement

### DIFF
--- a/scripts/clean_questions.js
+++ b/scripts/clean_questions.js
@@ -35,7 +35,6 @@ function asciiNormalize(str) {
     .replace(/\u2714/g, '')
     .replace(/\u27a4/g, '')
     .replace(/\u25bc/g, 'V')
-    .replace(/\u2192/g, '-') // included again for order
     .replace(/\u21d2/g, '=')
     .replace(/\u{1F4CC}/ug, '')
     .replace(/\u{1F53A}/ug, '')


### PR DESCRIPTION
## Summary
- remove redundant Unicode right arrow normalization in `clean_questions.js`

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688dd1df2ba4832bada4c8b0d3aef663