### PR TITLE
Refactor answer checking into shared function

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -77,20 +77,10 @@ function renderQuestion(q) {
 document.getElementById('checkBtn').onclick = function() {
   if (!currentQuestion) return;
   const options = document.getElementById('answerOptions');
-  let correct = false;
-  if (currentQuestion.answers && currentQuestion.answers.length) {
-    correct = selected == currentQuestion.correct_answer_number;
-    options.querySelectorAll('button').forEach(b => b.disabled = true);
-    const correctBtn = options.querySelector(`button[data-num='${currentQuestion.correct_answer_number}']`);
-    if (correctBtn) correctBtn.classList.add('correct');
-  } else {
-    const value = document.getElementById('calcInput').value.trim();
-    correct = value === (currentQuestion.correct_answer || '');
-  }
+  const input = document.getElementById('calcInput');
   const feedback = document.getElementById('feedback');
-  feedback.textContent = correct ? 'Correct!' : 'Incorrect';
-  feedback.className = correct ? 'correct' : 'incorrect';
-  questionRenderer.updateStats(currentQuestion.id, correct);
+  const value = currentQuestion.answers && currentQuestion.answers.length ? selected : input.value.trim();
+  questionRenderer.evaluateAnswer(currentQuestion, value, { options, feedback });
 };
 
 document.getElementById('revealBtn').onclick = function() {

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -95,5 +95,32 @@
     localStorage.setItem('questionStats', JSON.stringify(data));
   }
 
-  global.questionRenderer = { renderQuestion, updateStats, sanitize };
+  function evaluateAnswer(question, value, hooks){
+    hooks = hooks || {};
+    const optionsEl = hooks.options;
+    const feedbackEl = hooks.feedback;
+
+    let correct = false;
+    if (question.answers && question.answers.length) {
+      correct = String(value) == String(question.correct_answer_number);
+      if (optionsEl) {
+        optionsEl.querySelectorAll('button').forEach(b => b.disabled = true);
+        const correctBtn = optionsEl.querySelector(`button[data-num='${question.correct_answer_number}']`);
+        if (correctBtn) correctBtn.classList.add('correct');
+      }
+    } else {
+      correct = String(value).trim() === String(question.correct_answer || '');
+    }
+
+    if (feedbackEl) {
+      feedbackEl.textContent = correct ? 'Correct!' : 'Incorrect';
+      feedbackEl.className = (feedbackEl.className || '').replace(/\b(correct|incorrect)\b/g, '').trim();
+      feedbackEl.classList.add(correct ? 'correct' : 'incorrect');
+    }
+
+    updateStats(question.id, correct);
+    return correct;
+  }
+
+  global.questionRenderer = { renderQuestion, updateStats, sanitize, evaluateAnswer };
 })(this);

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -331,20 +331,9 @@
       const opts = document.querySelector('.options');
       const calc = document.querySelector('.calculator');
       const input = calc.querySelector('input');
-      let correct = false;
-      if(q.answers && q.answers.length){
-        correct = selected == q.correct_answer_number;
-        opts.querySelectorAll('button').forEach(b => b.disabled = true);
-        const correctBtn = opts.querySelector(`button[data-num='${q.correct_answer_number}']`);
-        if(correctBtn) correctBtn.classList.add('correct');
-      } else {
-        const value = input.value.trim();
-        correct = value === (q.correct_answer || '');
-      }
       const fb = document.querySelector('.feedback');
-      fb.textContent = correct ? 'Correct!' : 'Incorrect';
-      fb.className = 'feedback ' + (correct ? 'correct' : 'incorrect');
-      questionRenderer.updateStats(q.id, correct);
+      const value = q.answers && q.answers.length ? selected : input.value.trim();
+      questionRenderer.evaluateAnswer(q, value, { options: opts, feedback: fb });
       recordAnswer();
     };
 


### PR DESCRIPTION
## Summary
- introduce `evaluateAnswer` in `question_renderer.js` to centralize answer checking, feedback, and stat updates
- call the shared evaluator from main practice interfaces instead of duplicating logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dd386e908832ba61738eb99e4a58d