### PR TITLE
Add reusable answer reveal helper

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -85,24 +85,7 @@ document.getElementById('checkBtn').onclick = function() {
 
 document.getElementById('revealBtn').onclick = function() {
   if (!currentQuestion) return;
-  let answerText = '';
-  if (currentQuestion.answers && currentQuestion.answers.length) {
-    const obj = currentQuestion.answers.find(a => a.answer_number == currentQuestion.correct_answer_number);
-    answerText = obj ? obj.text : '';
-  } else {
-    answerText = currentQuestion.correct_answer || '';
-    if (currentQuestion.answer_unit) {
-      answerText += ' ' + currentQuestion.answer_unit;
-    }
-  }
-  const ans = document.getElementById('answer');
-  if (ans) {
-    ans.textContent = answerText ? `Answer: ${answerText}` : '';
-    ans.style.display = 'block';
-  }
-  const ex = document.getElementById('explanation');
-  ex.innerHTML = questionRenderer.sanitize(currentQuestion.why || 'No explanation');
-  ex.style.display = 'block';
+  questionRenderer.revealAnswer(currentQuestion, { answer: '#answer', explanation: '#explanation' });
 };
 
 document.getElementById('saveBtn').onclick = function() {
@@ -185,18 +168,6 @@ function revealStatsQuestion(q) {
     btn.textContent = 'Reveal Answer';
     return;
   }
-
-  let answerText = '';
-  if (q.answers && q.answers.length) {
-    const obj = q.answers.find(a => a.answer_number == q.correct_answer_number);
-    answerText = obj ? obj.text : '';
-  } else {
-    answerText = q.correct_answer || '';
-    if (q.answer_unit) answerText += ' ' + q.answer_unit;
-  }
-  ans.textContent = answerText ? `Answer: ${answerText}` : '';
-  ex.innerHTML = questionRenderer.sanitize(q.why || 'No explanation');
-  ans.style.display = 'block';
-  ex.style.display = 'block';
+  questionRenderer.revealAnswer(q, { answer: ans, explanation: ex });
   btn.textContent = 'Hide Answer';
 }

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -122,5 +122,38 @@
     return correct;
   }
 
-  global.questionRenderer = { renderQuestion, updateStats, sanitize, evaluateAnswer };
+  function revealAnswer(question, targets){
+    targets = targets || {};
+    const get = sel => {
+      if (!sel) return null;
+      return typeof sel === 'string' ? document.querySelector(sel) : sel;
+    };
+
+    const answerEl = get(targets.answer);
+    const explanationEl = get(targets.explanation);
+    const prefix = targets.prefix || 'Answer';
+
+    let answerText = '';
+    if (question.answers && question.answers.length) {
+      const obj = question.answers.find(a => a.answer_number == question.correct_answer_number);
+      answerText = obj ? obj.text : '';
+    } else {
+      answerText = question.correct_answer || '';
+      if (question.answer_unit) answerText += ' ' + question.answer_unit;
+    }
+
+    if (answerEl) {
+      answerEl.textContent = answerText ? `${prefix}: ${answerText}` : '';
+      answerEl.style.display = 'block';
+    }
+
+    if (explanationEl) {
+      explanationEl.innerHTML = sanitize(question.why || 'No explanation');
+      explanationEl.style.display = 'block';
+    }
+
+    return {answerText};
+  }
+
+  global.questionRenderer = { renderQuestion, updateStats, sanitize, evaluateAnswer, revealAnswer };
 })(this);

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -259,21 +259,11 @@
         if (responses[index]){
           fb.textContent = responses[index].correct ? 'Correct!' : 'Incorrect';
           fb.className = 'feedback ' + (responses[index].correct ? 'correct' : 'incorrect');
-          corr.textContent = responses[index].correctAnswer ? `Correct answer: ${responses[index].correctAnswer}` : '';
         } else {
           fb.textContent = 'Not answered';
           fb.className = 'feedback';
-          let correctText = '';
-          if(q.answers && q.answers.length){
-            const obj = q.answers.find(a => a.answer_number == q.correct_answer_number);
-            correctText = obj ? obj.text : '';
-          } else {
-            correctText = (q.correct_answer || '') + (q.answer_unit ? ` ${q.answer_unit}` : '');
-          }
-          corr.textContent = correctText ? `Correct answer: ${correctText}` : '';
         }
-        const expText = questionRenderer.sanitize(questions[index].why || '');
-        expl.innerHTML = expText;
+        questionRenderer.revealAnswer(q, { answer: corr, explanation: expl, prefix: 'Correct answer' });
         convertPdfLinks(expl);
         details.style.display = 'block';
       } else {


### PR DESCRIPTION
## Summary
- add `questionRenderer.revealAnswer` to centralize formatting of answers and explanations
- integrate new helper into main app and stats modal reveal buttons
- reuse helper when reviewing finished practice questions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dd4a05604832bbc1faae40e2a5d65