### PR TITLE
Use relative paths for question assets

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (container) container.classList.add('standalone');
   }
   if (!bankFiles) {
-    fetch('/static/banks.json')
+    fetch('../static/banks.json')
       .then(r => r.json())
       .then(data => {
         bankFiles = data;
@@ -52,12 +52,12 @@ async function loadQuestion() {
   const bank = document.getElementById('bankSelect').value;
   if (!bank) return;
   if (!bankFiles) {
-    bankFiles = await fetch('/static/banks.json').then(r => r.json());
+    bankFiles = await fetch('../static/banks.json').then(r => r.json());
   }
   const files = bankFiles[bank] || [];
   if (!files.length) return;
   const file = files[Math.floor(Math.random() * files.length)];
-  const qs = await fetch('/' + file).then(r => r.json());
+  const qs = await fetch('../' + file).then(r => r.json());
   const q = qs[Math.floor(Math.random() * qs.length)];
   renderQuestion(q);
 }
@@ -136,19 +136,19 @@ function loadStats() {
   const bank = document.getElementById('statsBankSelect').value;
   if (!bank) return;
   (async () => {
-    if (!bankFiles) {
-      bankFiles = await fetch('/static/banks.json').then(r => r.json());
-    }
-    const files = bankFiles[bank] || [];
-    let qs = [];
-    for (const f of files) {
-      const arr = await fetch('/' + f).then(r => r.json());
-      qs = qs.concat(arr);
-    }
-    statsQuestions = qs.sort((a,b) => (a.id||0) - (b.id||0));
-    renderStats();
-  })();
-}
+      if (!bankFiles) {
+        bankFiles = await fetch('../static/banks.json').then(r => r.json());
+      }
+      const files = bankFiles[bank] || [];
+      let qs = [];
+      for (const f of files) {
+        const arr = await fetch('../' + f).then(r => r.json());
+        qs = qs.concat(arr);
+      }
+      statsQuestions = qs.sort((a,b) => (a.id||0) - (b.id||0));
+      renderStats();
+    })();
+  }
 
 function renderStats() {
   const tbody = document.querySelector('#statsTable tbody');

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -99,7 +99,7 @@
       const files = bankMap[bank] || [];
       let all = [];
       for(const f of files){
-        const arr = await fetch('/' + f).then(r => r.json());
+        const arr = await fetch('../' + f).then(r => r.json());
         all = all.concat(arr);
       }
       for(let i=all.length-1;i>0;i--){


### PR DESCRIPTION
## Summary
- load `banks.json` and question files using relative paths so the app works when served from a subdirectory or local filesystem
- adjust practice page to fetch question files relative to the current directory

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "const fs=require('fs').promises; (async()=>{process.chdir('templates');const banks=JSON.parse(await fs.readFile('../static/banks.json','utf8'));const file=banks['clinical_mixed'][0];const qs=JSON.parse(await fs.readFile('../'+file,'utf8'));console.log('banks',Object.keys(banks).filter(k=>Array.isArray(banks[k])).length,'questions',qs.length);})();"`


------
https://chatgpt.com/codex/tasks/task_e_688ddc096510832b84969e9cfde01c2a