### PR TITLE
refactor: load question banks via single module

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -74,16 +74,6 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@2.3.10/dist/purify.min.js"></script>
   <script src="../static/question_renderer.js"></script>
-  <script type="module" src="../question_banks/calculations_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_mep_low_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_mixed_high_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_mixed_low_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_mixed_medium_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_otc_low_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_therapeutics_high_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_therapeutics_low_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
-  <script type="module" src="../question_banks/clinical_therapeutics_questions_low.js"></script>
   <script type="module" src="../static/banks.js"></script>
   <script type="module" src="../static/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove individual question bank script tags from index.html
- rely on static/banks.js as the sole source for loading question banks

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -sI http://localhost:8000/templates/index.html`

------
https://chatgpt.com/codex/tasks/task_e_688de62543f8832b88f2874b574bcff9