### PR TITLE
feat: support js modules in burp scripts

### DIFF
--- a/Burp/checkquestions.js
+++ b/Burp/checkquestions.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
-const fs = require('fs');
+const fs = require('fs/promises');
 const path = require('path');
 
 const OUTPUT_DIR = 'question_banks';
 
-function countQuestionsInFile(filepath) {
+async function countQuestionsInFile(filepath) {
   try {
-    const data = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+    const code = await fs.readFile(filepath, 'utf-8');
+    const mod = await import('data:text/javascript,' + encodeURIComponent(code));
+    const data = mod.default;
     return Array.isArray(data) ? data.length : 0;
   } catch (err) {
     console.error(`❌ Error reading ${filepath}: ${err}`);
@@ -14,15 +16,15 @@ function countQuestionsInFile(filepath) {
   }
 }
 
-function main() {
+async function main() {
   const questionBankTotals = {};
   const fileCounts = [];
 
-  const files = fs.readdirSync(OUTPUT_DIR).sort();
+  const files = (await fs.readdir(OUTPUT_DIR)).sort();
   for (const filename of files) {
-    if (filename.endsWith('.json')) {
+    if (filename.endsWith('.js')) {
       const filepath = path.join(OUTPUT_DIR, filename);
-      const count = countQuestionsInFile(filepath);
+      const count = await countQuestionsInFile(filepath);
       if (count !== null) {
         fileCounts.push([filename, count]);
         const bankName = filename.split('_questions')[0];

--- a/Burp/grabquestions.js
+++ b/Burp/grabquestions.js
@@ -77,16 +77,16 @@ async function main() {
 
   if (bankName === 'Calculations') {
     console.log(`\n📥 Scraping '${bankName}' questions (no weighting)...\n`);
-    outputFile = path.join('output', `${bankName.toLowerCase().replace(/ /g, '_')}_questions.json`);
+    outputFile = path.join('question_banks', `${bankName.toLowerCase().replace(/ /g, '_')}_questions.js`);
     url = `https://www.preregshortcuts.com/api/questions/get/?bank=${bankName.replace(/ /g, '+')}&num_questions=40`;
   } else {
     weighting = await promptForWeighting();
     console.log(`\n📥 Scraping '${bankName}' questions with '${weighting}' weighting...\n`);
-    outputFile = path.join('output', `${bankName.toLowerCase().replace(/ /g, '_')}_${weighting.toLowerCase()}_questions.json`);
+    outputFile = path.join('question_banks', `${bankName.toLowerCase().replace(/ /g, '_')}_${weighting.toLowerCase()}_questions.js`);
     url = `https://www.preregshortcuts.com/api/questions/get/?bank=${bankName.replace(/ /g, '+')}&num_questions=40&weighting=${weighting}`;
   }
 
-  fs.mkdirSync('output', { recursive: true });
+  fs.mkdirSync('question_banks', { recursive: true });
 
   const headers = {
     'Host': 'www.preregshortcuts.com',
@@ -113,7 +113,9 @@ async function main() {
 
   if (fs.existsSync(outputFile)) {
     try {
-      uniqueQuestions = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+      const code = fs.readFileSync(outputFile, 'utf8');
+      const mod = await import('data:text/javascript,' + encodeURIComponent(code));
+      uniqueQuestions = Array.isArray(mod.default) ? mod.default : [];
       seenHashes = new Set(uniqueQuestions.map(hashQuestion));
       console.log(`🔁 Loaded ${uniqueQuestions.length} existing unique questions for bank '${bankName}'${weightingText}.`);
     } catch (err) {
@@ -158,7 +160,7 @@ async function main() {
     await new Promise(res => setTimeout(res, 2000));
   }
 
-  fs.writeFileSync(outputFile, JSON.stringify(uniqueQuestions, null, 2));
+  fs.writeFileSync(outputFile, 'export default ' + JSON.stringify(uniqueQuestions, null, 2));
   console.log(`\n💾 Saved ${uniqueQuestions.length} unique questions to ${outputFile}`);
   rl.close();
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ templates/       # HTML templates for the interface
 Available banks are listed in `static/banks.js` which maps to modules in
 `question_banks/`.
 
+## Burp scripts
+
+Two helper scripts in `Burp/` operate directly on the JavaScript question modules:
+
+* `node Burp/checkquestions.js` – dynamically imports each file in `question_banks/` and prints question totals by bank.
+* `node Burp/grabquestions.js` – interactively fetches questions from the external API and saves them to `question_banks/` as ES modules. Existing files are imported to prevent duplicate entries.
+
+These scripts no longer read or write JSON; all data is handled as JavaScript modules.
+
 
 ## Using the interface
 


### PR DESCRIPTION
## Summary
- dynamically import question bank modules instead of JSON parsing
- allow question scraping script to read and write ES modules in `question_banks`
- document the updated Burp scripts in the README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node Burp/checkquestions.js`
- `node Burp/grabquestions.js`


------
https://chatgpt.com/codex/tasks/task_e_688de6c3d44c832b8ca925709b754ff9