### PR TITLE
Load question banks without modules for offline use

### DIFF
--- a/question_banks/calculations_questions.js
+++ b/question_banks/calculations_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.calculations = 
 [
   {
     "id": 790,

--- a/question_banks/clinical_mep_low_questions.js
+++ b/question_banks/clinical_mep_low_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.clinicalMepLow = 
 [
   {
     "id": 882,

--- a/question_banks/clinical_mixed_high_questions.js
+++ b/question_banks/clinical_mixed_high_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.clinicalMixedHigh = 
 [
   {
     "id": 1044,

--- a/question_banks/clinical_mixed_low_questions.js
+++ b/question_banks/clinical_mixed_low_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.clinicalMixedLow = 
 [
   {
     "id": 2495,

--- a/question_banks/clinical_mixed_medium_questions.js
+++ b/question_banks/clinical_mixed_medium_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.clinicalMixedMedium = 
 [
   {
     "id": 2154,

--- a/question_banks/clinical_otc_low_questions.js
+++ b/question_banks/clinical_otc_low_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.clinicalOtcLow = 
 [
   {
     "id": 885,

--- a/question_banks/clinical_therapeutics_high_questions.js
+++ b/question_banks/clinical_therapeutics_high_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.clinicalTherapeuticsHigh = 
 [
   {
     "id": 1010,

--- a/question_banks/clinical_therapeutics_low_questions.js
+++ b/question_banks/clinical_therapeutics_low_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.clinicalTherapeuticsLow = 
 [
   {
     "id": 2148,

--- a/question_banks/clinical_therapeutics_medium_questions.js
+++ b/question_banks/clinical_therapeutics_medium_questions.js
@@ -1,4 +1,4 @@
-export default 
+window.clinicalTherapeuticsMedium = 
 [
   {
     "id": 2155,

--- a/static/banks.js
+++ b/static/banks.js
@@ -1,18 +1,8 @@
-import calculations from '../question_banks/calculations_questions.js';
-import clinicalMepLow from '../question_banks/clinical_mep_low_questions.js';
-import clinicalMixedHigh from '../question_banks/clinical_mixed_high_questions.js';
-import clinicalMixedLow from '../question_banks/clinical_mixed_low_questions.js';
-import clinicalMixedMedium from '../question_banks/clinical_mixed_medium_questions.js';
-import clinicalOtcLow from '../question_banks/clinical_otc_low_questions.js';
-import clinicalTherapeuticsHigh from '../question_banks/clinical_therapeutics_high_questions.js';
-import clinicalTherapeuticsLow from '../question_banks/clinical_therapeutics_low_questions.js';
-import clinicalTherapeuticsMedium from '../question_banks/clinical_therapeutics_medium_questions.js';
-
-export default {
+window.banks = {
   _info: "Populate the question_banks/ directory with JavaScript modules exporting question arrays before using the interface",
-  calculations: [calculations],
-  clinical_mep: [clinicalMepLow],
-  clinical_mixed: [clinicalMixedHigh, clinicalMixedLow, clinicalMixedMedium],
-  clinical_otc: [clinicalOtcLow],
-  clinical_therapeutics: [clinicalTherapeuticsHigh, clinicalTherapeuticsLow, clinicalTherapeuticsMedium]
+  calculations: [window.calculations],
+  clinical_mep: [window.clinicalMepLow],
+  clinical_mixed: [window.clinicalMixedHigh, window.clinicalMixedLow, window.clinicalMixedMedium],
+  clinical_otc: [window.clinicalOtcLow],
+  clinical_therapeutics: [window.clinicalTherapeuticsHigh, window.clinicalTherapeuticsLow, window.clinicalTherapeuticsMedium]
 };

--- a/static/main.js
+++ b/static/main.js
@@ -1,8 +1,4 @@
-import banks from './banks.js';
-
-let currentQuestion;
-let selected;
-let bankFiles = banks;
+let currentQuestion, selected, bankFiles = window.banks;
 
 document.getElementById('loadBtn').addEventListener('click', loadQuestion);
 const practiceBtn = document.getElementById('practiceBtn');
@@ -71,7 +67,7 @@ function startPractice() {
     alert('Please enter a positive number of questions');
     return;
   }
-  window.location.href = `/templates/practice.html?bank=${encodeURIComponent(data.bank)}&num=${num}`;
+  window.location.href = `practice.html?bank=${encodeURIComponent(data.bank)}&num=${num}`;
 }
 
 function renderQuestion(q) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,8 +73,17 @@
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@2.3.10/dist/purify.min.js"></script>
+  <script src="../question_banks/calculations_questions.js"></script>
+  <script src="../question_banks/clinical_mep_low_questions.js"></script>
+  <script src="../question_banks/clinical_mixed_high_questions.js"></script>
+  <script src="../question_banks/clinical_mixed_low_questions.js"></script>
+  <script src="../question_banks/clinical_mixed_medium_questions.js"></script>
+  <script src="../question_banks/clinical_otc_low_questions.js"></script>
+  <script src="../question_banks/clinical_therapeutics_high_questions.js"></script>
+  <script src="../question_banks/clinical_therapeutics_low_questions.js"></script>
+  <script src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
+  <script src="../static/banks.js"></script>
   <script src="../static/question_renderer.js"></script>
-  <script type="module" src="../static/banks.js"></script>
-  <script type="module" src="../static/main.js"></script>
+  <script src="../static/main.js"></script>
 </body>
 </html>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -65,7 +65,7 @@
       <tbody></tbody>
     </table>
     <p class="score"></p>
-    <button class="home-btn" onclick="location.href='/'">Return Home</button>
+    <button class="home-btn" onclick="location.href='index.html'">Return Home</button>
   </section>
 
   <footer class="footer">
@@ -77,14 +77,20 @@
   </footer>
   </div>
 
+  <script src="../question_banks/calculations_questions.js"></script>
+  <script src="../question_banks/clinical_mep_low_questions.js"></script>
+  <script src="../question_banks/clinical_mixed_high_questions.js"></script>
+  <script src="../question_banks/clinical_mixed_low_questions.js"></script>
+  <script src="../question_banks/clinical_mixed_medium_questions.js"></script>
+  <script src="../question_banks/clinical_otc_low_questions.js"></script>
+  <script src="../question_banks/clinical_therapeutics_high_questions.js"></script>
+  <script src="../question_banks/clinical_therapeutics_low_questions.js"></script>
+  <script src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
+  <script src="../static/banks.js"></script>
   <script src="../static/question_renderer.js"></script>
-  <script type="module">
-    import banks from "../static/banks.js";
-    let questions = [];
-    let index = 0;
-    let selected = null;
-    let responses = [];
-    let reviewing = false;
+  <script>
+    const banks = window.banks;
+    let questions=[], index=0, selected=null, responses=[], reviewing=false;
     const backSummaryBtn = document.querySelector('.summary-btn');
     const homeTopBtn = document.querySelector('.home-top-btn');
 
@@ -386,7 +392,7 @@
 
     // Quick exit to home
     homeTopBtn.onclick = () => {
-      window.location.href = '/';
+      window.location.href = 'index.html';
     };
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Expose each question bank as a global array and bundle them via `window.banks`
- Drop ES module usage across pages and scripts so they can load from `file://`
- Navigate to the practice page with a relative path for offline compatibility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688de9ec3acc832bab2d7552a95c4f1a