### PR TITLE
Handle browser environment for question renderer

### DIFF
--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -168,5 +168,10 @@ function revealAnswer(question, targets) {
   return { answerText };
 }
 
-module.exports = { renderQuestion, updateStats, sanitize, evaluateAnswer, revealAnswer };
+const questionRendererObj = { renderQuestion, updateStats, sanitize, evaluateAnswer, revealAnswer };
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = questionRendererObj;
+} else {
+  window.questionRenderer = questionRendererObj;
+}
 


### PR DESCRIPTION
## Summary
- Ensure `question_renderer.js` works in both Node and browser environments by wrapping exports in an environment check.
- Expose a global `questionRenderer` in browsers while preserving `module.exports` for Node usage.

## Testing
- `npm test` *(fails: no test specified)*
- `node -e "const q=require('./static/question_renderer.js'); console.log(typeof q.renderQuestion);"`
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('./static/question_renderer.js','utf8');
const context={window:{}};
vm.runInNewContext(code, context);
console.log(typeof context.window.questionRenderer.renderQuestion);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_688df1fc5bb8832b8c05d6664f8390ec