### PR TITLE
refactor ascii normalization with char map

### DIFF
--- a/scripts/clean_questions.js
+++ b/scripts/clean_questions.js
@@ -5,42 +5,50 @@ const { sanitize } = require('../static/question_renderer.js');
 const INPUT_DIR = path.join(__dirname, '..', 'question_banks');
 const OUTPUT_DIR = path.join(__dirname, '..', 'output');
 
+// Map of problematic Unicode characters to their ASCII approximations
+const CHAR_MAP = {
+  '\u2018': "'",
+  '\u2019': "'",
+  '\u201C': '"',
+  '\u201D': '"',
+  '\u2013': '-',
+  '\u2014': '--',
+  '\u2192': '-',
+  '\u00A3': 'PS',
+  '\u00AE': '(r)',
+  '\u00D7': 'x',
+  '\u00F7': '/',
+  '\u00B0': 'deg',
+  '\u00B1': '+-',
+  '\u03B1': 'a',
+  '\u03B2': 'b',
+  '\u03BC': 'm',
+  '\u03C4': 't',
+  '\u2212': '-',
+  '\u2264': '<=',
+  '\u2265': '>=',
+  '\u221A': '',
+  '\u2248': '',
+  '\u2022': '*',
+  '\u2044': '/',
+  '\u2052': '%',
+  '\u2714': '',
+  '\u27A4': '',
+  '\u25BC': 'V',
+  '\u21D2': '=',
+  '\u{1F4CC}': '',
+  '\u{1F53A}': '',
+  '\u{1F9E0}': '',
+  '\u200B': ''
+};
+
 function asciiNormalize(str) {
   // remove diacritics by decomposing then stripping combining marks
   let out = str.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
   // approximate transliteration for common punctuation
-  out = out
-    .replace(/[\u2018\u2019]/g, "'")
-    .replace(/[\u201C\u201D]/g, '"')
-    .replace(/\u2013/g, '-')
-    .replace(/\u2014/g, '--')
-    .replace(/\u2192/g, '-')
-    .replace(/\u00a3/g, 'PS')
-    .replace(/\u00ae/g, '(r)')
-    .replace(/\u00d7/g, 'x')
-    .replace(/\u00f7/g, '/')
-    .replace(/\u00b0/g, 'deg')
-    .replace(/\u00b1/g, '+-')
-    .replace(/\u03b1/g, 'a')
-    .replace(/\u03b2/g, 'b')
-    .replace(/\u03bc/g, 'm')
-    .replace(/\u03c4/g, 't')
-    .replace(/\u2212/g, '-')
-    .replace(/\u2264/g, '<=')
-    .replace(/\u2265/g, '>=')
-    .replace(/\u221a/g, '')
-    .replace(/\u2248/g, '')
-    .replace(/\u2022/g, '*')
-    .replace(/\u2044/g, '/')
-    .replace(/\u2052/g, '%')
-    .replace(/\u2714/g, '')
-    .replace(/\u27a4/g, '')
-    .replace(/\u25bc/g, 'V')
-    .replace(/\u21d2/g, '=')
-    .replace(/\u{1F4CC}/ug, '')
-    .replace(/\u{1F53A}/ug, '')
-    .replace(/\u{1F9E0}/ug, '')
-    .replace(/\u200b/g, '');
+  for (const [char, replacement] of Object.entries(CHAR_MAP)) {
+    out = out.replace(new RegExp(char, 'gu'), replacement);
+  }
   return out;
 }
 


### PR DESCRIPTION
## Summary
- centralize Unicode to ASCII conversions in a `CHAR_MAP` object
- iterate over `CHAR_MAP` to apply replacements during ASCII normalization
- keep using built-in `String.normalize` for diacritic stripping

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688df85564e8832bb9f09ae7c20dd879