### PR TITLE
Fix question rendering issues

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -50,7 +50,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function loadQuestion() {
   const data = getSelectedBank('bankSelect');
-  if (!data) return;
+  if (!data) {
+    alert('Please select a bank');
+    return;
+  }
   const qs = data.files[Math.floor(Math.random() * data.files.length)];
   const q = qs[Math.floor(Math.random() * qs.length)];
   renderQuestion(q);

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -1,7 +1,13 @@
-function sanitize(text) {
-  text = (text || '').replace(/\u2028/g, '\n').replace(/\u00a0/g, ' ').replace(/\u200b/g, '');
+function sanitize(text, inline) {
+  text = (text || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\u2028/g, '\n')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\u200b/g, '');
   if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
-    return DOMPurify.sanitize(marked.parse(text));
+    const parsed = inline ? marked.parseInline(text) : marked.parse(text);
+    return DOMPurify.sanitize(parsed);
   }
   return text;
 }
@@ -47,7 +53,14 @@ function renderQuestion(question, config) {
   const explanationEl = get(config.explanation);
   const showInput = config.showInput !== false;
 
-  if (titleEl) titleEl.textContent = question.title || '';
+  if (titleEl) {
+    const title = sanitize(question.title || '', true);
+    if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
+      titleEl.innerHTML = title;
+    } else {
+      titleEl.textContent = title;
+    }
+  }
   if (textEl) {
     const txt = sanitize(question.text || '');
     if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
@@ -85,7 +98,7 @@ function renderQuestion(question, config) {
       if (optionsEl) optionsEl.style.display = 'none';
       if (inputEl) {
         inputEl.value = '';
-        inputEl.style.display = 'block';
+        inputEl.style.display = 'inline-block';
       }
       if (unitEl) {
         if (question.answer_unit) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -54,8 +54,6 @@ button:hover {
 }
 
 #qImg {
-  max-width: 100%;
-  height: auto;
   display: none;
 }
 
@@ -124,6 +122,7 @@ button:hover {
   text-align: left;
   cursor: pointer;
   background-color: #fff;
+  color: #000;
   transition: 0.2s;
 }
 
@@ -198,8 +197,12 @@ button:hover {
 }
 
 #sqImg {
+  display: none;
+}
+
+#questionArea img,
+#statsModal img {
   max-width: 100%;
   height: auto;
-  display: none;
 }
 


### PR DESCRIPTION
## Summary
- show prompt when loading a question without selecting a bank
- ensure Markdown titles, line breaks, and units render cleanly
- keep option text visible and images within question area

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dfa091910832b99e721f6eaa2834f