### PR TITLE
Fix question rendering issues

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -50,7 +50,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function loadQuestion() {
   const data = getSelectedBank('bankSelect');
-  if (!data) return;
+  if (!data) {
+    alert('Please select a bank');
+    return;
+  }
   const qs = data.files[Math.floor(Math.random() * data.files.length)];
   const q = qs[Math.floor(Math.random() * qs.length)];
   renderQuestion(q);

--- a/static/practice.css
+++ b/static/practice.css
@@ -169,6 +169,7 @@ body {
 .prompt {
   margin-top: 15px;
   font-weight: bold;
+  font-size: 16pt;
 }
 
 .calculator {

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -1,7 +1,13 @@
-function sanitize(text) {
-  text = (text || '').replace(/\u2028/g, '\n').replace(/\u00a0/g, ' ').replace(/\u200b/g, '');
+function sanitize(text, inline) {
+  text = (text || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/\u2028/g, '\n')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\u200b/g, '');
   if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
-    return DOMPurify.sanitize(marked.parse(text));
+    const parsed = inline ? marked.parseInline(text) : marked.parse(text);
+    return DOMPurify.sanitize(parsed);
   }
   return text;
 }
@@ -47,7 +53,14 @@ function renderQuestion(question, config) {
   const explanationEl = get(config.explanation);
   const showInput = config.showInput !== false;
 
-  if (titleEl) titleEl.textContent = question.title || '';
+  if (titleEl) {
+    const title = sanitize(question.title || '', true);
+    if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
+      titleEl.innerHTML = title;
+    } else {
+      titleEl.textContent = title;
+    }
+  }
   if (textEl) {
     const txt = sanitize(question.text || '');
     if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
@@ -85,7 +98,7 @@ function renderQuestion(question, config) {
       if (optionsEl) optionsEl.style.display = 'none';
       if (inputEl) {
         inputEl.value = '';
-        inputEl.style.display = 'block';
+        inputEl.style.display = 'inline-block';
       }
       if (unitEl) {
         if (question.answer_unit) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -53,9 +53,13 @@ button:hover {
   white-space: pre-line;
 }
 
+.question-title {
+  margin-top: 15px;
+  font-size: 16pt;
+  font-weight: bold;
+}
+
 #qImg {
-  max-width: 100%;
-  height: auto;
   display: none;
 }
 
@@ -124,6 +128,7 @@ button:hover {
   text-align: left;
   cursor: pointer;
   background-color: #fff;
+  color: #000;
   transition: 0.2s;
 }
 
@@ -198,8 +203,12 @@ button:hover {
 }
 
 #sqImg {
+  display: none;
+}
+
+#questionArea img,
+#statsModal img {
   max-width: 100%;
   height: auto;
-  display: none;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
 
       <div id="questionArea">
         <p id="qText"></p>
-        <h2 id="qTitle"></h2>
+        <p id="qTitle" class="question-title"></p>
         <img id="qImg" alt="Question image">
         <div id="answerOptions" class="options"></div>
         <input type="text" id="calcInput"><span id="answerUnit"></span>
@@ -61,7 +61,7 @@
           <div class="modal-content">
             <button id="sqCloseBtn" class="close">&times;</button>
             <p id="sqText"></p>
-            <h3 id="sqTitle"></h3>
+            <p id="sqTitle" class="question-title"></p>
             <img id="sqImg" alt="Question image">
             <button id="sqRevealBtn">Reveal Answer</button>
             <div id="sqAnswer"></div>


### PR DESCRIPTION
## Summary
- show prompt when loading a question without selecting a bank
- ensure Markdown titles, line breaks, and units render cleanly
- keep option text visible and images within question area
- render question titles as 16pt text instead of headers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dfa091910832b99e721f6eaa2834f