### PR TITLE
style: enlarge question titles

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -169,6 +169,13 @@ body {
 .prompt {
   margin-top: 15px;
   font-weight: bold;
+  font-size: 16pt;
+}
+
+.q-number {
+  font-size: 16pt;
+  font-weight: bold;
+  margin: 0;
 }
 
 .calculator {

--- a/static/styles.css
+++ b/static/styles.css
@@ -53,6 +53,11 @@ button:hover {
   white-space: pre-line;
 }
 
+.question-title {
+  font-size: 16pt;
+  font-weight: bold;
+}
+
 #qImg {
   display: none;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
 
       <div id="questionArea">
         <p id="qText"></p>
-        <h2 id="qTitle"></h2>
+        <p id="qTitle" class="question-title"></p>
         <img id="qImg" alt="Question image">
         <div id="answerOptions" class="options"></div>
         <input type="text" id="calcInput"><span id="answerUnit"></span>
@@ -61,7 +61,7 @@
           <div class="modal-content">
             <button id="sqCloseBtn" class="close">&times;</button>
             <p id="sqText"></p>
-            <h3 id="sqTitle"></h3>
+            <p id="sqTitle" class="question-title"></p>
             <img id="sqImg" alt="Question image">
             <button id="sqRevealBtn">Reveal Answer</button>
             <div id="sqAnswer"></div>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -37,7 +37,7 @@
     </div>
 
     <section class="question-area">
-      <h2 class="q-number"></h2>
+      <p class="q-number"></p>
       <p class="scenario"></p>
       <p class="prompt"></p>
       <div class="options"></div>


### PR DESCRIPTION
## Summary
- Display question titles as regular paragraph text in index and practice views
- Apply consistent 16pt styling to question prompts and numbers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dff58b264832b8fd4c6a0071297b1