### PR TITLE
Include markdown parsing scripts on practice page

### DIFF
--- a/templates/practice.html
+++ b/templates/practice.html
@@ -77,6 +77,8 @@
   </footer>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@2.3.10/dist/purify.min.js"></script>
   <script src="../question_banks/calculations_questions.js"></script>
   <script src="../question_banks/clinical_mep_low_questions.js"></script>
   <script src="../question_banks/clinical_mixed_high_questions.js"></script>


### PR DESCRIPTION
## Summary
- load Marked and DOMPurify libraries before question bank scripts on practice page

## Testing
- `npm test` *(fails: Error: no test specified)*
- Node simulation of `revealAnswer` renders `<p>First line</p><ul><li>item 1</li><li>item 2</li></ul>`

------
https://chatgpt.com/codex/tasks/task_e_688e0ae97498832b9f5bbd920b208cdc