### PR TITLE
Enable line breaks in Markdown renderer

### DIFF
--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -6,6 +6,7 @@ function sanitize(text, inline) {
     .replace(/\u00a0/g, ' ')
     .replace(/\u200b/g, '');
   if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
+    marked.setOptions({ breaks: true });
     const parsed = inline ? marked.parseInline(text) : marked.parse(text);
     return DOMPurify.sanitize(parsed);
   }


### PR DESCRIPTION
## Summary
- Ensure Markdown parser inserts `<br>` for newline characters via `marked.setOptions({ breaks: true })` in the sanitizer so list items render on separate lines across pages.

## Testing
- `node - <<'NODE'
...sanitization demo...
NODE`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e0aecf744832b90893abe7ab1cea2