### PR TITLE
feat: sanitize answers in summary table

### DIFF
--- a/templates/practice.html
+++ b/templates/practice.html
@@ -376,12 +376,34 @@
         const tr = document.createElement('tr');
         const ua = r ? r.text || '' : '';
         const ca = r ? r.correctAnswer || '' : '';
-        const uaHTML = questionRenderer.sanitize(ua, true);
-        const caHTML = questionRenderer.sanitize(ca, true);
         const correct = r ? r.correct : false;
         if(correct) correctCount++;
         const icon = correct ? '✔' : '✘';
-        tr.innerHTML = `<td>${i+1}</td><td>${uaHTML}</td><td>${caHTML}</td><td class="result-icon ${correct ? 'correct' : 'incorrect'}">${icon}</td><td><button data-idx='${i}'>Review</button></td>`;
+
+        const numTd = document.createElement('td');
+        numTd.textContent = i + 1;
+
+        const uaTd = document.createElement('td');
+        uaTd.innerHTML = questionRenderer.sanitize(ua, true);
+
+        const caTd = document.createElement('td');
+        caTd.innerHTML = questionRenderer.sanitize(ca, true);
+
+        const resultTd = document.createElement('td');
+        resultTd.className = `result-icon ${correct ? 'correct' : 'incorrect'}`;
+        resultTd.textContent = icon;
+
+        const reviewTd = document.createElement('td');
+        const reviewBtn = document.createElement('button');
+        reviewBtn.dataset.idx = i;
+        reviewBtn.textContent = 'Review';
+        reviewTd.appendChild(reviewBtn);
+
+        tr.appendChild(numTd);
+        tr.appendChild(uaTd);
+        tr.appendChild(caTd);
+        tr.appendChild(resultTd);
+        tr.appendChild(reviewTd);
         tbody.appendChild(tr);
       });
       score.textContent = `You answered ${correctCount} of ${questions.length} correctly.`;


### PR DESCRIPTION
## Summary
- Sanitize and parse user and correct answers with `questionRenderer.sanitize(..., true)` before inserting them into the summary table.

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_688e0ee39980832b9c7a3b6d45ce3104