### PR TITLE
refactor: evaluate answers with renderer

### DIFF
--- a/static/practice.js
+++ b/static/practice.js
@@ -1,0 +1,38 @@
+function recordAnswer(showFeedback){
+  const q = questions[index];
+  const calc = document.querySelector('.calculator');
+  const input = calc.querySelector('input');
+  const opts = document.querySelector('.options');
+  const fb = document.querySelector('.feedback');
+
+  let userAns = null;
+  let userText = '';
+  if(q.answers && q.answers.length){
+    userAns = selected;
+    const obj = q.answers.find(a => a.answer_number == selected);
+    userText = obj ? obj.text : '';
+  } else {
+    userAns = input.value.trim();
+    userText = userAns ? userAns + (q.answer_unit ? ` ${q.answer_unit}` : '') : '';
+  }
+
+  let correctText = '';
+  if(q.answers && q.answers.length){
+    const obj = q.answers.find(a => a.answer_number == q.correct_answer_number);
+    correctText = obj ? obj.text : '';
+  } else {
+    correctText = (q.correct_answer || '') + (q.answer_unit ? ` ${q.answer_unit}` : '');
+  }
+
+  const hooks = showFeedback ? { options: opts, feedback: fb } : undefined;
+  const correct = questionRenderer.evaluateAnswer(q, userAns, hooks);
+
+  responses[index] = { answer: userAns, text: userText, correctAnswer: correctText, correct };
+  updateProgress();
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { recordAnswer };
+} else {
+  window.recordAnswer = recordAnswer;
+}

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -91,6 +91,7 @@
   <script src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
   <script src="../static/banks.js"></script>
   <script src="../static/question_renderer.js"></script>
+  <script src="../static/practice.js"></script>
   <script>
     const banks = window.banks;
     let questions=[], index=0, selected=null, responses=[], reviewing=false;
@@ -301,32 +302,6 @@
     }
 
 
-    function recordAnswer(){
-      const q = questions[index];
-      const calc = document.querySelector('.calculator');
-      const input = calc.querySelector('input');
-      let userAns = null;
-      let userText = '';
-      if(q.answers && q.answers.length){
-        userAns = selected;
-        const obj = q.answers.find(a => a.answer_number == selected);
-        userText = obj ? obj.text : '';
-      } else {
-        userAns = input.value.trim();
-        userText = userAns ? userAns + (q.answer_unit ? ` ${q.answer_unit}` : '') : '';
-      }
-      let correctText = '';
-      if(q.answers && q.answers.length){
-        const obj = q.answers.find(a => a.answer_number == q.correct_answer_number);
-        correctText = obj ? obj.text : '';
-      } else {
-        correctText = (q.correct_answer || '') + (q.answer_unit ? ` ${q.answer_unit}` : '');
-      }
-      const correct = q.answers && q.answers.length ? (selected == q.correct_answer_number) : (userAns === (q.correct_answer || ''));
-      responses[index] = {answer: userAns, text: userText, correctAnswer: correctText, correct};
-      updateProgress();
-   }
-
   document.querySelector('.next-btn').onclick = () => {
     recordAnswer();
     if(index < questions.length - 1){ index++; renderQuestion(); }
@@ -341,14 +316,7 @@
   };
 
   document.querySelector('.check-btn').onclick = () => {
-      const q = questions[index];
-      const opts = document.querySelector('.options');
-      const calc = document.querySelector('.calculator');
-      const input = calc.querySelector('input');
-      const fb = document.querySelector('.feedback');
-      const value = q.answers && q.answers.length ? selected : input.value.trim();
-      questionRenderer.evaluateAnswer(q, value, { options: opts, feedback: fb });
-      recordAnswer();
+      recordAnswer(true);
     };
 
       document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- centralize answer recording in new `practice.js` using `questionRenderer.evaluateAnswer`
- load the new script and call `recordAnswer(true)` when checking answers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e11fe7804832ba7623367f8f56acd