### PR TITLE
Handle invalid question banks in practice page

### DIFF
--- a/static/practice.js
+++ b/static/practice.js
@@ -26,6 +26,11 @@ function startTimer() {
 function loadQuestions() {
   const params = new URLSearchParams(window.location.search);
   const bank = params.get('bank');
+  if (!bank || !(bank in banks)) {
+    alert('Invalid question bank.');
+    window.location.href = 'index.html';
+    return false;
+  }
   let num = parseInt(params.get('num') || '10', 10);
   const files = banks[bank] || [];
   let all = [];
@@ -38,6 +43,13 @@ function loadQuestions() {
   }
   questions = all.slice(0, num);
   responses = Array(questions.length).fill(null);
+  if (!questions.length) {
+    const main = document.querySelector('.main');
+    if (main) {
+      main.innerHTML = '<p>No questions available for this bank.</p>';
+    }
+  }
+  return true;
 }
 
 function initNav() {
@@ -247,8 +259,8 @@ document.querySelector('.check-btn').onclick = () => {
 
 document.addEventListener('DOMContentLoaded', () => {
   startTimer();
-  loadQuestions();
-  if (!questions.length) return;
+  const loaded = loadQuestions();
+  if (!loaded || !questions.length) return;
   initNav();
   renderQuestion();
 });


### PR DESCRIPTION
## Summary
- Validate requested question bank and redirect to home when invalid
- Show notice when no questions are available
- Prevent question initialization when loading fails

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_688e163557c0832b87fc6e915139bcc6