### PR TITLE
Refactor practice page to reuse index question IDs

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -166,7 +166,7 @@ body {
   text-align: left;
 }
 
-.prompt {
+.question-title {
   margin-top: 15px;
   font-weight: bold;
   font-size: 16pt;
@@ -227,7 +227,7 @@ body {
   color: #fff;
 }
 
-.feedback {
+#feedback {
   margin-top: 10px;
   font-weight: bold;
 }
@@ -285,12 +285,12 @@ body {
   border-radius: 4px;
 }
 
-.correct-answer {
+#answer {
   font-weight: bold;
   margin-bottom: 5px;
 }
 
-.explanation {
+#explanation {
   margin-top: 5px;
 }
 

--- a/static/practice.js
+++ b/static/practice.js
@@ -139,25 +139,24 @@ function renderQuestion() {
   closePdf();
   document.querySelector('.q-number').textContent = `Question ${index + 1}`;
   const result = questionRenderer.renderQuestion(q, {
-    text: '.scenario',
-    title: '.prompt',
-    options: '.options',
-    input: '.calculator input',
-    unit: '.calculator .unit',
-    feedback: '.feedback',
-    answer: '.correct-answer',
-    explanation: '.explanation',
+    text: '#qText',
+    title: '#qTitle',
+    options: '#answerOptions',
+    input: '#calcInput',
+    unit: '#answerUnit',
+    feedback: '#feedback',
+    answer: '#answer',
+    explanation: '#explanation',
     showInput: true
   });
-  convertPdfLinks(document.querySelector('.scenario'));
-  convertPdfLinks(document.querySelector('.prompt'));
-  const opts = document.querySelector('.options');
+  convertPdfLinks(document.getElementById('qText'));
+  convertPdfLinks(document.getElementById('qTitle'));
+  const opts = document.getElementById('answerOptions');
   const calc = document.querySelector('.calculator');
-  const input = calc.querySelector('input');
-  const unit = calc.querySelector('.unit');
+  const input = document.getElementById('calcInput');
   const details = document.querySelector('.details');
-  const corr = details.querySelector('.correct-answer');
-  const expl = details.querySelector('.explanation');
+  const corr = document.getElementById('answer');
+  const expl = document.getElementById('explanation');
   if (q.answers && q.answers.length) {
     calc.style.display = 'none';
     result.buttons.forEach(btn => {
@@ -181,25 +180,24 @@ function renderQuestion() {
   } else {
     calc.style.display = 'block';
     input.value = responses[index] ? (responses[index].answer || '') : '';
-    unit.textContent = q.answer_unit || '';
     input.disabled = reviewing;
   }
   if (reviewing) {
-    const fb = document.querySelector('.feedback');
+    const fb = document.getElementById('feedback');
     if (responses[index]) {
       fb.textContent = responses[index].correct ? 'Correct!' : 'Incorrect';
-      fb.className = 'feedback ' + (responses[index].correct ? 'correct' : 'incorrect');
+      fb.className = responses[index].correct ? 'correct' : 'incorrect';
     } else {
       fb.textContent = 'Not answered';
-      fb.className = 'feedback';
+      fb.className = '';
     }
     questionRenderer.revealAnswer(q, { answer: corr, explanation: expl, prefix: 'Correct answer' });
     convertPdfLinks(expl);
     details.style.display = 'block';
   } else {
-    const fb = document.querySelector('.feedback');
+    const fb = document.getElementById('feedback');
     fb.textContent = '';
-    fb.className = 'feedback';
+    fb.className = '';
     details.style.display = 'none';
   }
   updateProgress();
@@ -208,8 +206,7 @@ function renderQuestion() {
 
 function recordAnswer() {
   const q = questions[index];
-  const calc = document.querySelector('.calculator');
-  const input = calc.querySelector('input');
+  const input = document.getElementById('calcInput');
   let userAns = null;
   let userText = '';
   if (q.answers && q.answers.length) {
@@ -248,10 +245,9 @@ document.querySelector('.flag-current-btn').onclick = () => {
 
 document.querySelector('.check-btn').onclick = () => {
   const q = questions[index];
-  const opts = document.querySelector('.options');
-  const calc = document.querySelector('.calculator');
-  const input = calc.querySelector('input');
-  const fb = document.querySelector('.feedback');
+  const opts = document.getElementById('answerOptions');
+  const input = document.getElementById('calcInput');
+  const fb = document.getElementById('feedback');
   const value = q.answers && q.answers.length ? selected : input.value.trim();
   questionRenderer.evaluateAnswer(q, value, { options: opts, feedback: fb });
   recordAnswer();

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -39,20 +39,20 @@
 
     <section class="question-area">
       <p class="q-number"></p>
-      <p class="scenario"></p>
-      <p class="prompt"></p>
-      <div class="options"></div>
+      <p id="qText"></p>
+      <p id="qTitle" class="question-title"></p>
+      <div id="answerOptions" class="options"></div>
       <div class="calculator" style="display:none">
         <span class="icon">&#128425;</span>
         <label>Answer</label>
-        <input type="number">
-        <span class="unit"></span>
+        <input type="number" id="calcInput">
+        <span class="unit" id="answerUnit"></span>
       </div>
       <button class="check-btn">Check</button>
-      <div class="feedback"></div>
+      <div id="feedback"></div>
       <div class="details" style="display:none">
-        <div class="correct-answer"></div>
-        <div class="explanation"></div>
+        <div id="answer"></div>
+        <div id="explanation"></div>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary
- Align practice question markup with index IDs (#qText, #qTitle, #answerOptions, #calcInput, #answerUnit, #feedback, #answer, #explanation)
- Use questionRenderer with shared IDs and showInput=true for practice rendering
- Update practice styles to target new IDs

## Testing
- `npm test` *(fails: no test specified)*
- `python3 -m http.server 8000 &` then `curl -I http://localhost:8000/templates/index.html` and `curl -I http://localhost:8000/templates/practice.html`


------
https://chatgpt.com/codex/tasks/task_e_688e21dcaea0832ba20a50bb66d5532b