### PR TITLE
Handle missing question bank files gracefully

### DIFF
--- a/static/practice.js
+++ b/static/practice.js
@@ -28,6 +28,14 @@ function loadQuestions() {
   }
   let num = parseInt(params.get('num') || '10', 10);
   const files = banks[bank] || [];
+  if (files.length === 0) {
+    console.warn(`No files found for bank: ${bank}`);
+    const main = document.querySelector('.main');
+    if (main) {
+      main.innerHTML = '<p>No questions available for this bank.</p>';
+    }
+    return false;
+  }
   let all = [];
   for (const arr of files) {
     all = all.concat(arr);


### PR DESCRIPTION
## Summary
- Warn and abort when a selected question bank has no associated files
- Inform users via the main section when no questions are available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f41ef8840832b8d9eb44cbaaa0bc2