### PR TITLE
Remove redundant script from practice page

### DIFF
--- a/static/practice.js
+++ b/static/practice.js
@@ -3,6 +3,14 @@ let questions = [], index = 0, selected = null, responses = [], reviewing = fals
 let backSummaryBtn, homeTopBtn, timerEl;
 let pdfZoom = 1, pdfPane, pdfFrame;
 
+function toggleFlag(id) {
+  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
+  if (!data[id]) data[id] = { right: 0, wrong: 0, saved: false };
+  data[id].saved = !data[id].saved;
+  localStorage.setItem('questionStats', JSON.stringify(data));
+  return data[id].saved;
+}
+
 function startTimer() {
   const start = Date.now();
   function pad(num) {

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -91,7 +91,6 @@
   <script src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
   <script src="../static/banks.js"></script>
   <script src="../static/question_renderer.js"></script>
-  <script src="../static/main.js"></script>
   <script src="../static/practice.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove unused `main.js` from `practice.html`
- Inline flag toggling logic within `practice.js` to preserve functionality

## Testing
- `npm test` *(fails: no test specified)*
- `python -m http.server` & `curl http://localhost:8000/templates/practice.html?bank=calculations&num=2`

------
https://chatgpt.com/codex/tasks/task_e_688f45720dd0832b87e8752c97b78730