### PR TITLE
Handle missing stats modal close button

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -186,9 +186,12 @@ function showStatsQuestion(id) {
   revealBtn.addEventListener('click', () => revealStatsQuestion(q));
 }
 
-document.getElementById('sqCloseBtn').addEventListener('click', function() {
-  document.getElementById('statsModal').style.display = 'none';
-});
+const sqClose = document.getElementById('sqCloseBtn');
+if (sqClose) {
+  sqClose.addEventListener('click', () => {
+    document.getElementById('statsModal').style.display = 'none';
+  });
+}
 
 function revealStatsQuestion(q) {
   const ans = document.getElementById('sqAnswer');


### PR DESCRIPTION
## Summary
- avoid TypeError when stats modal close button is absent

## Testing
- `npm test` (fails: Error: no test specified)
- `node` stubbed DOM snippet verifying no TypeError when stats modal elements are missing


------
https://chatgpt.com/codex/tasks/task_e_688f457ae078832ba032412cd8d7cc3b