### PR TITLE
refactor: centralize question styling

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -130,29 +130,6 @@ body {
   overflow: auto;
 }
 
-.options {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.options button {
-  display: block;
-  width: 100%;
-  border: 2px solid #ccc;
-  padding: 12px 16px;
-  border-radius: 4px;
-  font-size: 16px;
-  text-align: left;
-  cursor: pointer;
-  background-color: #fff;
-  transition: 0.2s;
-}
-
-.options button:hover {
-  border-color: #0072ce;
-}
-
 .dose-table {
   width: 100%;
   border-collapse: collapse;
@@ -168,8 +145,6 @@ body {
 
 .question-title {
   margin-top: 15px;
-  font-weight: bold;
-  font-size: 16pt;
 }
 
 .q-number {
@@ -227,29 +202,6 @@ body {
   color: #fff;
 }
 
-#feedback {
-  margin-top: 10px;
-  font-weight: bold;
-}
-
-.correct {
-  color: #2e7d32;
-}
-
-.incorrect {
-  color: #c62828;
-}
-
-.options button.selected {
-  border-color: #e09d2d;
-  background-color: #fff6e0;
-}
-
-.options button.correct {
-  border-color: #d4af37;
-  background-color: #fffbe6;
-}
-
 .summary {
   padding: 20px;
 }
@@ -270,12 +222,6 @@ body {
   text-align: center;
   font-weight: bold;
   width: 60px;
-}
-.summary-table .correct {
-  color: #2e7d32;
-}
-.summary-table .incorrect {
-  color: #c62828;
 }
 
 .details {

--- a/static/question.css
+++ b/static/question.css
@@ -1,0 +1,58 @@
+.question-title {
+  font-weight: bold;
+  font-size: 16pt;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.options button {
+  display: block;
+  width: 100%;
+  border: 2px solid #ccc;
+  padding: 12px 16px;
+  border-radius: 4px;
+  text-align: left;
+  cursor: pointer;
+  background-color: #fff;
+  color: #000;
+  transition: 0.2s;
+  font-size: 16px;
+}
+
+.options button:hover {
+  border-color: #0072ce;
+}
+
+.options button.selected {
+  border-color: #e09d2d;
+  background-color: #fff6e0;
+}
+
+.options button.correct {
+  border-color: #d4af37;
+  background-color: #fffbe6;
+}
+
+#feedback {
+  margin-top: 10px;
+  font-weight: bold;
+}
+
+.correct {
+  color: #2e7d32;
+}
+
+.incorrect {
+  color: #c62828;
+}
+
+#questionArea img,
+#statsModal img,
+.question-area img {
+  max-width: 100%;
+  height: auto;
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -53,11 +53,6 @@ button:hover {
   white-space: pre-line;
 }
 
-.question-title {
-  font-size: 16pt;
-  font-weight: bold;
-}
-
 #qImg {
   display: none;
 }
@@ -97,52 +92,6 @@ button:hover {
   display: none;
   margin-top: 10px;
   font-style: italic;
-}
-
-#feedback {
-  margin-top: 10px;
-  font-weight: bold;
-}
-
-.correct {
-  color: #2e7d32;
-}
-
-.incorrect {
-  color: #c62828;
-}
-
-.options {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.options button {
-  display: block;
-  width: 100%;
-  border: 2px solid #ccc;
-  padding: 12px 16px;
-  border-radius: 4px;
-  text-align: left;
-  cursor: pointer;
-  background-color: #fff;
-  color: #000;
-  transition: 0.2s;
-}
-
-.options button:hover {
-  border-color: #0072ce;
-}
-
-.options button.selected {
-  border-color: #e09d2d;
-  background-color: #fff6e0;
-}
-
-.options button.correct {
-  border-color: #d4af37;
-  background-color: #fffbe6;
 }
 
 #statsArea {
@@ -205,9 +154,4 @@ button:hover {
   display: none;
 }
 
-#questionArea img,
-#statsModal img {
-  max-width: 100%;
-  height: auto;
-}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Question Bank</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap">
+  <link rel="stylesheet" href="../static/question.css">
   <link rel="stylesheet" href="../static/styles.css">
 </head>
 <body>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Practice Test</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap">
+  <link rel="stylesheet" href="../static/question.css">
   <link rel="stylesheet" href="../static/practice.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- extract shared question styles into new `static/question.css`
- trim duplicate rules from `static/styles.css` and `static/practice.css`
- link `question.css` from index and practice templates for consistent rendering

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -s http://localhost:8000/templates/index.html | head -n 20`
- `curl -s http://localhost:8000/templates/practice.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688f4b107708832bbeb22f1d6b414d3c