### PR TITLE
Replace question paragraphs with div containers

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -143,10 +143,6 @@ body {
   text-align: left;
 }
 
-.question-title {
-  margin-top: 15px;
-}
-
 .q-number {
   font-size: 16pt;
   font-weight: bold;

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
     </div>
 
       <div id="questionArea">
-        <p id="qText"></p>
+        <div id="qText"></div>
         <p id="qTitle" class="question-title"></p>
         <img id="qImg" alt="Question image">
         <div id="answerOptions" class="options"></div>
@@ -61,7 +61,7 @@
         <div id="statsModal" class="modal-overlay">
           <div class="modal-content">
             <button id="sqCloseBtn" class="close">&times;</button>
-            <p id="sqText"></p>
+            <div id="sqText"></div>
             <p id="sqTitle" class="question-title"></p>
             <img id="sqImg" alt="Question image">
             <button id="sqRevealBtn">Reveal Answer</button>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -40,7 +40,7 @@
 
     <section class="question-area">
       <p class="q-number"></p>
-      <p id="qText"></p>
+      <div id="qText"></div>
       <p id="qTitle" class="question-title"></p>
       <div id="answerOptions" class="options"></div>
       <div class="calculator" style="display:none">


### PR DESCRIPTION
## Summary
- Render question text and stats text in `<div>` elements instead of paragraphs.
- Align practice page styles with shared question styling by removing custom margin rule.
- Confirmed scripts reference question text elements by ID selectors only.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f4f83e5e4832bb75d4b1d4a5fe1ff