### PR TITLE
Improve score summary layout and display percentage

### DIFF
--- a/static/practice.js
+++ b/static/practice.js
@@ -278,7 +278,7 @@ function showSummary() {
     tr.appendChild(reviewTd);
     tbody.appendChild(tr);
   });
-  score.textContent = `You answered ${correctCount} of ${questions.length} correctly.`;
+  score.textContent = `You answered ${correctCount} of ${questions.length} correctly (${Math.round(correctCount / questions.length * 100)}%).`;
   summary.style.display = 'block';
   document.querySelector('.finish-btn').style.display = 'none';
   summary.querySelectorAll('button[data-idx]').forEach(btn => {

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -60,13 +60,13 @@
 
   <section class="summary" style="display:none">
     <h2>Test Summary</h2>
+    <p class="score"></p>
     <table class="summary-table">
       <thead>
         <tr><th>#</th><th>Your Answer</th><th>Correct Answer</th><th>Result</th><th>Review</th></tr>
       </thead>
       <tbody></tbody>
     </table>
-    <p class="score"></p>
     <button class="home-btn" onclick="location.href='index.html'">Return Home</button>
   </section>
 


### PR DESCRIPTION
## Summary
- Move score paragraph above summary table for clearer layout
- Show percentage correct in test summary

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f529a23f8832b9f512c445ca29632