### PR TITLE
Add spacing for timer in practice header

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -33,6 +33,10 @@ body {
   width: 0%;
 }
 
+.timer {
+  margin-right: 10px;
+}
+
 .finish-btn {
   background: #f6c71a;
   color: #000;


### PR DESCRIPTION
## Summary
- add `.timer` style with right margin to separate timer from header controls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f529ced64832b96420a1110fe7560