### PR TITLE
Map bank keys to display labels and show in practice test

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,5 +1,13 @@
 let currentQuestion, selected, bankFiles = window.banks;
 
+const bankLabels = {
+  calculations: 'Calculations',
+  clinical_mep: 'Clinical MEP',
+  clinical_mixed: 'Clinical Mixed',
+  clinical_otc: 'Clinical OTC',
+  clinical_therapeutics: 'Clinical Therapeutics'
+};
+
 const loadBtn = document.getElementById('loadBtn');
 if (loadBtn) loadBtn.addEventListener('click', loadQuestion);
 const practiceBtn = document.getElementById('practiceBtn');
@@ -16,13 +24,13 @@ function populateBankSelects(data) {
     if (bankSelect) {
       const opt1 = document.createElement('option');
       opt1.value = name;
-      opt1.textContent = name;
+      opt1.textContent = bankLabels[name] || name;
       bankSelect.appendChild(opt1);
     }
     if (statsSelect) {
       const opt2 = document.createElement('option');
       opt2.value = name;
-      opt2.textContent = name;
+      opt2.textContent = bankLabels[name] || name;
       statsSelect.appendChild(opt2);
     }
   });

--- a/static/practice.js
+++ b/static/practice.js
@@ -1,3 +1,10 @@
+const bankLabels = {
+  calculations: 'Calculations',
+  clinical_mep: 'Clinical MEP',
+  clinical_mixed: 'Clinical Mixed',
+  clinical_otc: 'Clinical OTC',
+  clinical_therapeutics: 'Clinical Therapeutics'
+};
 const banks = window.banks;
 let questions = [], index = 0, selected = null, responses = [], reviewing = false;
 let backSummaryBtn, homeTopBtn, timerEl;
@@ -31,6 +38,10 @@ function loadQuestions() {
   console.log('URLSearchParams:', URLSearchParams);
   const params = new URLSearchParams(window.location.search);
   const bank = params.get('bank');
+  const titleEl = document.querySelector('.test-title');
+  if (titleEl) {
+    titleEl.textContent = bankLabels[bank] || bank;
+  }
   if (!bank || !(bank in banks)) {
     alert('Invalid question bank.');
     window.location.href = 'index.html';

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -11,7 +11,7 @@
 <body>
   <div class="container">
   <header class="header">
-    <span class="test-title">Test: 2025 example questions Part 1</span>
+    <span class="test-title"></span>
     <div class="progress"><div class="bar" style="width:0%"></div></div>
     <span class="timer"></span>
     <div class="header-right">


### PR DESCRIPTION
## Summary
- Add bank label mapping for friendly names
- Use labels for select options and practice test title
- Remove hard-coded practice test title text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f52a2ddec832b8154d4e01eb8ee3c