### PR TITLE
Track practice time in summary

### DIFF
--- a/static/practice.js
+++ b/static/practice.js
@@ -1,6 +1,7 @@
 const banks = window.banks;
 let questions = [], index = 0, selected = null, responses = [], reviewing = false;
 let backSummaryBtn, homeTopBtn, timerEl;
+let timerId, startTime;
 let pdfZoom = 1, pdfPane, pdfFrame;
 
 function toggleFlag(id) {
@@ -12,18 +13,18 @@ function toggleFlag(id) {
 }
 
 function startTimer() {
-  const start = Date.now();
+  startTime = Date.now();
   function pad(num) {
     return num.toString().padStart(2, '0');
   }
   function update() {
-    const elapsed = Math.floor((Date.now() - start) / 1000);
+    const elapsed = Math.floor((Date.now() - startTime) / 1000);
     const mins = Math.floor(elapsed / 60);
     const secs = elapsed % 60;
     timerEl.textContent = `${pad(mins)}:${pad(secs)}`;
   }
   update();
-  setInterval(update, 1000);
+  timerId = setInterval(update, 1000);
 }
 
 function loadQuestions() {
@@ -233,6 +234,7 @@ function recordAnswer() {
 
 function showSummary() {
   recordAnswer();
+  clearInterval(timerId);
   reviewing = false;
   closePdf();
   backSummaryBtn.style.display = 'none';
@@ -242,6 +244,14 @@ function showSummary() {
   const summary = document.querySelector('.summary');
   const tbody = summary.querySelector('tbody');
   const score = summary.querySelector('.score');
+  const timeTakenEl = summary.querySelector('.time-taken');
+  const elapsedSec = Math.floor((Date.now() - startTime) / 1000);
+  const mins = Math.floor(elapsedSec / 60);
+  const secs = elapsedSec % 60;
+  if (timeTakenEl) {
+    const pad = num => num.toString().padStart(2, '0');
+    timeTakenEl.textContent = `Time taken: ${pad(mins)}:${pad(secs)}`;
+  }
   tbody.textContent = '';
   let correctCount = 0;
   responses.forEach((r, i) => {

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -66,6 +66,7 @@
       </thead>
       <tbody></tbody>
     </table>
+    <p class="time-taken"></p>
     <p class="score"></p>
     <button class="home-btn" onclick="location.href='index.html'">Return Home</button>
   </section>


### PR DESCRIPTION
## Summary
- Track timer start time and interval ID to manage practice session timing.
- Display elapsed time in summary and stop timer when the test ends.
- Add summary element to show the formatted time taken.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f52a39304832b9ac212c2ae277e89