### PR TITLE
Ensure active question stays visible

### DIFF
--- a/static/practice.js
+++ b/static/practice.js
@@ -100,7 +100,11 @@ function updateNav() {
   const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
   document.querySelectorAll('.nav li').forEach((li, i) => {
     const q = questions[i];
-    li.classList.toggle('active', i === index);
+    const isActive = i === index;
+    li.classList.toggle('active', isActive);
+    if (isActive) {
+      li.scrollIntoView({ block: 'nearest' });
+    }
     const flagged = data[q.id] && data[q.id].saved;
     if (flagged) {
       li.classList.add('flagged');


### PR DESCRIPTION
## Summary
- Scroll the active question number into view when navigation updates

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node - <<'NODE'` ... `NODE`


------
https://chatgpt.com/codex/tasks/task_e_688f52a77b34832bab2060767af479f4