### PR TITLE
Align practice footer with content width

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -168,17 +168,26 @@ body {
 .footer {
   position: fixed;
   bottom: 0;
-  left: 0;
-  right: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   padding: 10px 20px;
   background: #e5e9f0;
 }
 
+.nav-btns {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
+
 .nav-btns button {
-  margin-left: 10px;
+  margin: 0 10px;
   padding: 6px 12px;
   border-radius: 4px;
   border: none;
@@ -186,7 +195,6 @@ body {
 }
 
 .flag-current-btn {
-  margin-left: 10px;
   padding: 6px 12px;
   border-radius: 4px;
   border: none;


### PR DESCRIPTION
## Summary
- Center the practice footer and limit its width to 900px so it matches the main content container.
- Arrange footer navigation buttons within a flex container to keep them inside layout bounds.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f52a97ca8832b9e646e60e39186e3