### PR TITLE
Use session set for question flagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Open `templates/index.html` directly in your browser to use the interface—no w
    summary screen you can **Review** individual questions with feedback shown on each one and use the **Home**
    link to return to the start page.
 4. **Question statistics** – right/wrong counts are stored
-   in `localStorage` under `questionStats`. Flagged status should not be stored after test ends. The index page provides a "Check
+   in `localStorage` under `questionStats`. Flags are kept only for the current
+   session and cleared when the test ends. The index page provides a "Check
    Question Stats" form for looking up stats by question ID.
 5. **Folder structure** – question bank JavaScript modules live in `question_banks/`.
    The available banks are registered in `static/banks.js`.
@@ -102,9 +103,9 @@ start a full practice session:
 
 Use the **Back** and **Next** buttons at the bottom of the practice page to move
 between questions. Each question number in the sidebar has a small flag icon—
-click it to mark that question for review. Flagging and your answers are saved
-in `localStorage` so you can revisit them later. The progress bar in the header
-shows how far through the test you are.
+click it to mark that question for review. Flags only last for the current
+session, while your answers are saved in `localStorage` so you can revisit them
+later. The progress bar in the header shows how far through the test you are.
 
 ### Finishing a test
 
@@ -117,8 +118,8 @@ of the summary screen returns you to the start page.
 
 The browser keeps track of how often you answer each question correctly or
 incorrectly. These counts are stored in `localStorage` under the key
-`questionStats` along with whether you flagged the question for review. Use the
-"Check Question Stats" form on the index page to look up your history for a
+`questionStats`. Flags are not persisted and are cleared when a test ends. Use
+the "Check Question Stats" form on the index page to look up your history for a
 given question ID.
 
 ### Folder structure

--- a/static/practice.js
+++ b/static/practice.js
@@ -2,13 +2,15 @@ const banks = window.banks;
 let questions = [], index = 0, selected = null, responses = [], reviewing = false;
 let backSummaryBtn, homeTopBtn, timerEl;
 let pdfZoom = 1, pdfPane, pdfFrame;
+const flagged = new Set();
 
 function toggleFlag(id) {
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
-  if (!data[id]) data[id] = { right: 0, wrong: 0, saved: false };
-  data[id].saved = !data[id].saved;
-  localStorage.setItem('questionStats', JSON.stringify(data));
-  return data[id].saved;
+  if (flagged.has(id)) {
+    flagged.delete(id);
+    return false;
+  }
+  flagged.add(id);
+  return true;
 }
 
 function startTimer() {
@@ -69,12 +71,11 @@ function loadQuestions() {
 function initNav() {
   const nav = document.querySelector('.nav');
   nav.textContent = '';
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
   questions.forEach((q, i) => {
     const li = document.createElement('li');
     li.innerHTML = `${i + 1}<button class="flag-btn" title="Flag">\u2691</button>`;
     if (i === 0) li.classList.add('active');
-    if (data[q.id] && data[q.id].saved) li.classList.add('flagged');
+    if (flagged.has(q.id)) li.classList.add('flagged');
     const flag = li.querySelector('.flag-btn');
     flag.onclick = (e) => {
       e.stopPropagation();
@@ -97,16 +98,11 @@ function updateProgress() {
 }
 
 function updateNav() {
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
   document.querySelectorAll('.nav li').forEach((li, i) => {
     const q = questions[i];
     li.classList.toggle('active', i === index);
-    const flagged = data[q.id] && data[q.id].saved;
-    if (flagged) {
-      li.classList.add('flagged');
-    } else {
-      li.classList.remove('flagged');
-    }
+    const isFlagged = flagged.has(q.id);
+    li.classList.toggle('flagged', isFlagged);
   });
 }
 
@@ -293,6 +289,7 @@ function showSummary() {
       renderQuestion();
     };
   });
+  flagged.clear();
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- track flagged questions in-memory during a practice session
- drop localStorage for flags and clear them after showing summary
- document session-only flagging in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f52ab2714832b9c8ed5b30ffaa2fb