### PR TITLE
feat: track flags in session

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ questionRenderer.revealAnswer(question, {
 });
 
 // Toggle flagged status for review
-const flagged = toggleFlag(question.id); // true when saved
+const flagged = toggleFlag(question.id); // true when flagged
 ```
 
 Both `static/main.js` and `static/practice.js` call these helpers so the
@@ -102,9 +102,10 @@ start a full practice session:
 
 Use the **Back** and **Next** buttons at the bottom of the practice page to move
 between questions. Each question number in the sidebar has a small flag icon—
-click it to mark that question for review. Flagging and your answers are saved
-in `localStorage` so you can revisit them later. The progress bar in the header
-shows how far through the test you are.
+click it to mark that question for review. Your answers are stored in
+`localStorage`, while flags live only for the current session and are cleared
+when the test ends. The progress bar in the header shows how far through the
+test you are.
 
 ### Finishing a test
 
@@ -117,9 +118,9 @@ of the summary screen returns you to the start page.
 
 The browser keeps track of how often you answer each question correctly or
 incorrectly. These counts are stored in `localStorage` under the key
-`questionStats` along with whether you flagged the question for review. Use the
-"Check Question Stats" form on the index page to look up your history for a
-given question ID.
+`questionStats`. Flagged status is tracked in-memory for the current session and
+is discarded when the test ends. Use the "Check Question Stats" form on the
+index page to look up your history for a given question ID.
 
 ### Folder structure
 

--- a/static/main.js
+++ b/static/main.js
@@ -1,4 +1,5 @@
 let currentQuestion, selected, bankFiles = window.banks;
+const flagged = new Set();
 
 const bankLabels = {
   calculations: 'Calculations',
@@ -47,11 +48,12 @@ function getSelectedBank(id) {
 }
 
 function toggleFlag(id) {
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
-  if (!data[id]) data[id] = { right: 0, wrong: 0, saved: false };
-  data[id].saved = !data[id].saved;
-  localStorage.setItem('questionStats', JSON.stringify(data));
-  return data[id].saved;
+  if (flagged.has(id)) {
+    flagged.delete(id);
+    return false;
+  }
+  flagged.add(id);
+  return true;
 }
 
 window.toggleFlag = toggleFlag;

--- a/static/practice.js
+++ b/static/practice.js
@@ -9,13 +9,15 @@ const banks = window.banks;
 let questions = [], index = 0, selected = null, responses = [], reviewing = false;
 let backSummaryBtn, homeTopBtn, timerEl;
 let pdfZoom = 1, pdfPane, pdfFrame;
+const flagged = new Set();
 
 function toggleFlag(id) {
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
-  if (!data[id]) data[id] = { right: 0, wrong: 0, saved: false };
-  data[id].saved = !data[id].saved;
-  localStorage.setItem('questionStats', JSON.stringify(data));
-  return data[id].saved;
+  if (flagged.has(id)) {
+    flagged.delete(id);
+    return false;
+  }
+  flagged.add(id);
+  return true;
 }
 
 function startTimer() {
@@ -93,12 +95,11 @@ function loadQuestions() {
 function initNav() {
   const nav = document.querySelector('.nav');
   nav.textContent = '';
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
   questions.forEach((q, i) => {
     const li = document.createElement('li');
     li.innerHTML = `${i + 1}<button class="flag-btn" title="Flag">\u2691</button>`;
     if (i === 0) li.classList.add('active');
-    if (data[q.id] && data[q.id].saved) li.classList.add('flagged');
+    if (flagged.has(q.id)) li.classList.add('flagged');
     const flag = li.querySelector('.flag-btn');
     flag.onclick = (e) => {
       e.stopPropagation();
@@ -121,7 +122,6 @@ function updateProgress() {
 }
 
 function updateNav() {
-  const data = JSON.parse(localStorage.getItem('questionStats') || '{}');
   document.querySelectorAll('.nav li').forEach((li, i) => {
     const q = questions[i];
     const isActive = i === index;
@@ -129,8 +129,7 @@ function updateNav() {
     if (isActive) {
       li.scrollIntoView({ block: 'nearest' });
     }
-    const flagged = data[q.id] && data[q.id].saved;
-    if (flagged) {
+    if (flagged.has(q.id)) {
       li.classList.add('flagged');
     } else {
       li.classList.remove('flagged');
@@ -317,6 +316,7 @@ function showSummary() {
       renderQuestion();
     };
   });
+  flagged.clear();
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- replace flag localStorage storage with in-memory Set
- update navigation helpers to use session flags
- clear flags when showing summary and document session-only behavior

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f5620b2e4832b937e01411b38f3e8