### PR TITLE
Align answer field across index and practice pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ const flagged = toggleFlag(question.id); // true when flagged
 Both `static/main.js` and `static/practice.js` call these helpers so the
 single‑question view and practice interface behave consistently.
 
+When updating the question markup, mirror changes in both
+`templates/index.html` and `templates/practice.html` so they render the
+answer field identically (a simple "Answer" label and input without
+preceding icons). Keeping these pages in sync avoids confusing
+differences between the single question view and the practice test.
+
 ## Burp scripts
 
 Two helper scripts in `Burp/` operate directly on the JavaScript question modules:

--- a/static/main.js
+++ b/static/main.js
@@ -111,7 +111,10 @@ function renderQuestion(q) {
     showInput: true
   });
   const options = document.getElementById('answerOptions');
+  const calc = document.querySelector('.calculator');
+  const input = document.getElementById('calcInput');
   if (q.answers && q.answers.length) {
+    if (calc) calc.style.display = 'none';
     result.buttons.forEach(btn => {
       btn.addEventListener('click', () => {
         options.querySelectorAll('button').forEach(b => b.classList.remove('selected'));
@@ -119,6 +122,9 @@ function renderQuestion(q) {
         selected = btn.dataset.num;
       });
     });
+  } else if (calc) {
+    calc.style.display = 'block';
+    input.value = '';
   }
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -83,6 +83,18 @@ button:hover {
   margin-left: 4px;
 }
 
+.calculator {
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.calculator input {
+  width: 80px;
+  padding: 4px;
+  margin-left: 8px;
+}
+
 #explanation {
   display: none;
   margin-top: 10px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,11 @@
         <p id="qTitle" class="question-title"></p>
         <img id="qImg" alt="Question image">
         <div id="answerOptions" class="options"></div>
-        <input type="text" id="calcInput"><span id="answerUnit"></span>
+        <div class="calculator" style="display:none">
+          <label>Answer</label>
+          <input type="number" id="calcInput">
+          <span class="unit" id="answerUnit"></span>
+        </div>
         <div class="button-row">
           <button id="checkBtn">Check</button>
           <button id="revealBtn">Reveal</button>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -43,7 +43,6 @@
       <p id="qTitle" class="question-title"></p>
       <div id="answerOptions" class="options"></div>
       <div class="calculator" style="display:none">
-        <span class="icon">&#128425;</span>
         <label>Answer</label>
         <input type="number" id="calcInput">
         <span class="unit" id="answerUnit"></span>


### PR DESCRIPTION
## Summary
- Remove calculator icon from practice page and display only the answer label and input
- Align index page markup with practice page for answer entry and style it consistently
- Document requirement to keep question markup synced between index and practice pages

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f5c2cdd90832b8f0f27b6631c3c73