### PR TITLE
Reorder practice footer controls and enlarge button fonts

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -45,6 +45,7 @@ body {
   border-radius: 4px;
   cursor: pointer;
   margin-right: 10px;
+  font-size: 18px;
 }
 
 .summary-btn,
@@ -56,6 +57,7 @@ body {
   border-radius: 4px;
   cursor: pointer;
   margin-right: 10px;
+  font-size: 18px;
 }
 
 .main {
@@ -187,7 +189,7 @@ body {
 .nav-btns {
   width: 100%;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
 }
 
 .nav-btns button {
@@ -196,6 +198,7 @@ body {
   border-radius: 4px;
   border: none;
   cursor: pointer;
+  font-size: 18px;
 }
 
 .flag-current-btn {

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -71,9 +71,9 @@
 
   <footer class="footer">
     <div class="nav-btns">
-      <button type="button" class="back-btn">Back</button>
+      <button type="button" class="flag-current-btn" title="Flag Question">🚩</button>
+      <button type="button" class="back-btn">❮ Back</button>
       <button type="button" class="next-btn">Next ❯</button>
-      <button type="button" class="flag-current-btn">Flag</button>
     </div>
   </footer>
   </div>


### PR DESCRIPTION
## Summary
- group practice page footer buttons on the right in Flag, Back, Next order
- enlarge navigation and header buttons for improved readability

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f6149d088832bb49bf4c275ef81f0