### PR TITLE
Move summary home link to header

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -248,17 +248,10 @@ body {
   margin-top: 5px;
 }
 
-/* Home button in summary section */
-.home-btn {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  padding: 6px 12px;
-  border: none;
-  border-radius: 4px;
-  background: #f6c71a;
-  color: #000;
-  cursor: pointer;
+/* Align action buttons in the header */
+.header-right {
+  display: flex;
+  align-items: center;
 }
 
 /* PDF viewer pane */

--- a/static/practice.js
+++ b/static/practice.js
@@ -307,7 +307,7 @@ function showSummary() {
   reviewing = false;
   closePdf();
   backSummaryBtn.style.display = 'none';
-  homeTopBtn.style.display = 'none';
+  homeTopBtn.style.display = 'inline-block';
   document.querySelector('.main').style.display = 'none';
   document.querySelector('.footer').style.display = 'none';
   const summary = document.querySelector('.summary');

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -66,7 +66,6 @@
       </thead>
       <tbody></tbody>
     </table>
-    <button type="button" class="home-btn" onclick="location.href='index.html'">Return Home</button>
   </section>
 
   <footer class="footer">


### PR DESCRIPTION
## Summary
- remove fixed bottom summary home button and rely on top-aligned Home button
- align header action buttons with new `.header-right` flex styling
- show header Home button when displaying test summary

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f6147e2d4832bbdc47e41e541bb6e