### PR TITLE
Enable inputs in stats modal

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -189,14 +189,19 @@ function showStatsQuestion(id) {
   if (!q) return;
   const overlay = document.getElementById('statsModal');
   overlay.style.display = 'flex';
-  questionRenderer.renderQuestion(q, {
+  const result = questionRenderer.renderQuestion(q, {
     text: '#sqText',
     title: '#sqTitle',
     img: '#sqImg',
+    options: '#sqOptions',
+    input: '#sqCalcInput',
+    unit: '#sqAnswerUnit',
     answer: '#sqAnswer',
     explanation: '#sqExplanation',
-    showInput: false
+    showInput: true
   });
+  if (result.buttons) result.buttons.forEach(btn => (btn.disabled = true));
+  if (result.input) result.input.disabled = true;
   const revealBtn = document.getElementById('sqRevealBtn');
   revealBtn.textContent = 'Reveal Answer';
   revealBtn.addEventListener('click', () => revealStatsQuestion(q));

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,6 +68,12 @@
             <div id="sqText"></div>
             <p id="sqTitle" class="question-title"></p>
             <img id="sqImg" alt="Question image">
+            <div id="sqOptions" class="options"></div>
+            <div class="calculator" style="display:none">
+              <label>Answer</label>
+              <input type="number" id="sqCalcInput">
+              <span class="unit" id="sqAnswerUnit"></span>
+            </div>
             <button id="sqRevealBtn">Reveal Answer</button>
             <div id="sqAnswer"></div>
             <div id="sqExplanation"></div>


### PR DESCRIPTION
## Summary
- Show inputs in stats question modal
- Disable stats modal inputs and options to prevent interaction
- Mirror practice-question layout in the statistics modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c24fc8c832bb4dd255063d988c5