### PR TITLE
refactor pdf handling into shared utility

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -67,6 +67,18 @@ document.addEventListener('DOMContentLoaded', function() {
     if (container) container.classList.add('standalone');
   }
   populateBankSelects(bankFiles);
+
+  const pdfPane = document.getElementById('pdfPane');
+  const pdfFrame = document.getElementById('pdfFrame');
+  if (pdfPane && pdfFrame) {
+    document.querySelector('.pdf-close')?.addEventListener('click', questionRenderer.closePdf);
+    document.querySelector('.pdf-zoom-in')?.addEventListener('click', () => {
+      questionRenderer.zoomPdfIn();
+    });
+    document.querySelector('.pdf-zoom-out')?.addEventListener('click', () => {
+      questionRenderer.zoomPdfOut();
+    });
+  }
 });
 
 function loadQuestion() {
@@ -110,6 +122,8 @@ function renderQuestion(q) {
     explanation: '#explanation',
     showInput: true
   });
+  questionRenderer.convertPdfLinks(document.getElementById('qText'));
+  questionRenderer.convertPdfLinks(document.getElementById('qTitle'));
   const options = document.getElementById('answerOptions');
   const calc = document.querySelector('.calculator');
   const input = document.getElementById('calcInput');
@@ -145,6 +159,7 @@ if (revealBtn) {
   revealBtn.addEventListener('click', function() {
     if (!currentQuestion) return;
     questionRenderer.revealAnswer(currentQuestion, { answer: '#answer', explanation: '#explanation' });
+    questionRenderer.convertPdfLinks(document.getElementById('explanation'));
   });
 }
 
@@ -197,6 +212,8 @@ function showStatsQuestion(id) {
     explanation: '#sqExplanation',
     showInput: false
   });
+  questionRenderer.convertPdfLinks(document.getElementById('sqText'));
+  questionRenderer.convertPdfLinks(document.getElementById('sqTitle'));
   const revealBtn = document.getElementById('sqRevealBtn');
   revealBtn.textContent = 'Reveal Answer';
   revealBtn.addEventListener('click', () => revealStatsQuestion(q));
@@ -221,5 +238,6 @@ function revealStatsQuestion(q) {
     return;
   }
   questionRenderer.revealAnswer(q, { answer: ans, explanation: ex });
+  questionRenderer.convertPdfLinks(ex);
   btn.textContent = 'Hide Answer';
 }

--- a/static/practice.js
+++ b/static/practice.js
@@ -10,7 +10,6 @@ let bank;
 let questions = [], index = 0, selected = null, responses = [], reviewing = false;
 let backSummaryBtn, homeTopBtn, timerEl;
 let timerId, startTime;
-let pdfZoom = 1, pdfPane, pdfFrame;
 const flagged = new Set();
 let finished = false;
 let summaryData = null;
@@ -186,35 +185,10 @@ function updateNav() {
   });
 }
 
-
-
-function openPdf(url) {
-  pdfFrame.src = url;
-  pdfZoom = 1;
-  pdfFrame.style.transform = 'scale(1)';
-  pdfPane.style.display = 'flex';
-}
-
-function closePdf() {
-  pdfPane.style.display = 'none';
-  pdfFrame.src = '';
-}
-
-function convertPdfLinks(el) {
-  if (!el) return;
-  el.querySelectorAll('a[href$=".pdf"]').forEach(a => {
-    const btn = document.createElement('button');
-    btn.textContent = 'Open PDF';
-    btn.className = 'pdf-btn';
-    btn.onclick = (e) => { e.preventDefault(); openPdf(a.href); };
-    a.replaceWith(btn);
-  });
-}
-
 function renderQuestion() {
   const q = questions[index];
   selected = null;
-  closePdf();
+  questionRenderer.closePdf();
   document.querySelector('.q-number').textContent = `Question ${index + 1}`;
   const result = questionRenderer.renderQuestion(q, {
     text: '#qText',
@@ -227,8 +201,8 @@ function renderQuestion() {
     explanation: '#explanation',
     showInput: true
   });
-  convertPdfLinks(document.getElementById('qText'));
-  convertPdfLinks(document.getElementById('qTitle'));
+  questionRenderer.convertPdfLinks(document.getElementById('qText'));
+  questionRenderer.convertPdfLinks(document.getElementById('qTitle'));
   const opts = document.getElementById('answerOptions');
   const calc = document.querySelector('.calculator');
   const input = document.getElementById('calcInput');
@@ -270,7 +244,7 @@ function renderQuestion() {
       fb.className = '';
     }
     questionRenderer.revealAnswer(q, { answer: corr, explanation: expl, prefix: 'Correct answer' });
-    convertPdfLinks(expl);
+    questionRenderer.convertPdfLinks(expl);
     details.style.display = 'block';
   } else {
     const fb = document.getElementById('feedback');
@@ -308,7 +282,7 @@ function showSummary() {
   clearInterval(timerId);
   reviewing = false;
   finished = true;
-  closePdf();
+  questionRenderer.closePdf();
   backSummaryBtn.style.display = 'none';
   homeTopBtn.style.display = 'inline-block';
   document.querySelector('.main').style.display = 'none';
@@ -392,8 +366,8 @@ document.addEventListener('DOMContentLoaded', () => {
   backSummaryBtn = document.querySelector('.summary-btn');
   homeTopBtn = document.querySelector('.home-top-btn');
   timerEl = document.querySelector('.timer');
-  pdfPane = document.getElementById('pdfPane');
-  pdfFrame = document.getElementById('pdfFrame');
+  const pdfPane = document.getElementById('pdfPane');
+  const pdfFrame = document.getElementById('pdfFrame');
 
   if (!backSummaryBtn || !homeTopBtn || !timerEl || !pdfPane || !pdfFrame) {
     return;
@@ -402,14 +376,12 @@ document.addEventListener('DOMContentLoaded', () => {
   backSummaryBtn.style.display = 'none';
   homeTopBtn.style.display = 'none';
 
-  document.querySelector('.pdf-close')?.addEventListener('click', closePdf);
+  document.querySelector('.pdf-close')?.addEventListener('click', questionRenderer.closePdf);
   document.querySelector('.pdf-zoom-in')?.addEventListener('click', () => {
-    pdfZoom += 0.1;
-    pdfFrame.style.transform = `scale(${pdfZoom})`;
+    questionRenderer.zoomPdfIn();
   });
   document.querySelector('.pdf-zoom-out')?.addEventListener('click', () => {
-    pdfZoom = Math.max(0.1, pdfZoom - 0.1);
-    pdfFrame.style.transform = `scale(${pdfZoom})`;
+    questionRenderer.zoomPdfOut();
   });
 
   document.querySelector('.next-btn')?.addEventListener('click', () => {

--- a/static/question.css
+++ b/static/question.css
@@ -56,3 +56,45 @@
   max-width: 100%;
   height: auto;
 }
+
+.main {
+  display: flex;
+}
+
+/* PDF viewer pane */
+.pdf-pane {
+  flex: 0 0 40%;
+  max-width: 40%;
+  display: none;
+  flex-direction: column;
+  height: 100%;
+  background: #fff;
+  border-right: 1px solid #ccc;
+}
+
+.pdf-controls {
+  padding: 5px;
+  background: #e5e9f0;
+  border-bottom: 1px solid #ccc;
+}
+
+.pdf-controls button {
+  margin-right: 5px;
+  padding: 4px 8px;
+}
+
+.pdf-wrapper {
+  flex: 1;
+  overflow: auto;
+}
+
+.pdf-btn {
+  margin-top: 10px;
+}
+
+#pdfFrame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  transform-origin: top left;
+}

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -43,6 +43,59 @@ function enhanceLinksAndImages(el) {
   });
 }
 
+let pdfZoom = 1;
+
+function getPdfElements() {
+  return {
+    pane: document.getElementById('pdfPane'),
+    frame: document.getElementById('pdfFrame')
+  };
+}
+
+function openPdf(url) {
+  const { pane, frame } = getPdfElements();
+  if (!pane || !frame) return;
+  frame.src = url;
+  pdfZoom = 1;
+  frame.style.transform = 'scale(1)';
+  pane.style.display = 'flex';
+}
+
+function closePdf() {
+  const { pane, frame } = getPdfElements();
+  if (!pane || !frame) return;
+  pane.style.display = 'none';
+  frame.src = '';
+}
+
+function convertPdfLinks(el) {
+  if (!el) return;
+  el.querySelectorAll('a[href$=".pdf"]').forEach(a => {
+    const btn = document.createElement('button');
+    btn.textContent = 'Open PDF';
+    btn.className = 'pdf-btn';
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      openPdf(a.href);
+    });
+    a.replaceWith(btn);
+  });
+}
+
+function zoomPdfIn() {
+  const { frame } = getPdfElements();
+  if (!frame) return;
+  pdfZoom += 0.1;
+  frame.style.transform = `scale(${pdfZoom})`;
+}
+
+function zoomPdfOut() {
+  const { frame } = getPdfElements();
+  if (!frame) return;
+  pdfZoom = Math.max(0.1, pdfZoom - 0.1);
+  frame.style.transform = `scale(${pdfZoom})`;
+}
+
 function resetUI({ feedbackEl, answerEl, explanationEl, optionsEl, inputEl, unitEl }) {
   if (feedbackEl) {
     feedbackEl.textContent = '';
@@ -225,7 +278,18 @@ function revealAnswer(question, targets) {
   return { answerText };
 }
 
-const questionRendererObj = { renderQuestion, updateStats, sanitize, evaluateAnswer, revealAnswer };
+const questionRendererObj = {
+  renderQuestion,
+  updateStats,
+  sanitize,
+  evaluateAnswer,
+  revealAnswer,
+  openPdf,
+  closePdf,
+  convertPdfLinks,
+  zoomPdfIn,
+  zoomPdfOut
+};
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = questionRendererObj;
 } else {

--- a/static/styles.css
+++ b/static/styles.css
@@ -47,6 +47,7 @@ button:hover {
   border-radius: 5px;
   background-color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  flex: 1;
 }
 
 #qText {

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,6 +22,18 @@
       <button id="practiceBtn">Start Practice</button>
     </div>
 
+    <div class="main">
+      <div class="pdf-pane" id="pdfPane" style="display:none">
+        <div class="pdf-controls">
+          <button type="button" class="pdf-zoom-in">+</button>
+          <button type="button" class="pdf-zoom-out">-</button>
+          <button type="button" class="pdf-close">&times;</button>
+        </div>
+        <div class="pdf-wrapper">
+          <iframe id="pdfFrame" src="" title="PDF viewer"></iframe>
+        </div>
+      </div>
+
       <div id="questionArea">
         <div id="qText"></div>
         <p id="qTitle" class="question-title"></p>
@@ -41,8 +53,9 @@
         <div id="answer"></div>
         <div id="explanation"></div>
       </div>
+    </div>
 
-      <div id="statsArea">
+    <div id="statsArea">
         <h2>Question Statistics</h2>
         <label for="statsBankSelect">Select Bank:</label>
         <select id="statsBankSelect">


### PR DESCRIPTION
## Summary
- centralize PDF viewer helpers and link conversion in `question_renderer.js`
- apply `convertPdfLinks` in question and stats rendering paths
- add shared PDF viewer markup and styles to index page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c2d989c832b9d432bab219627aa