### PR TITLE
style: set nav list font size

### DIFF
--- a/static/practice.css
+++ b/static/practice.css
@@ -93,6 +93,7 @@ body {
   background-color: #e8f0f8;
   color: #000;
   font-weight: bold;
+  font-size: 18px;
   cursor: pointer;
   position: relative;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- ensure navigation list items use 18px font size to match other buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f6d207c24832b83b09044de565cdb