### PR TITLE
Ensure single reveal handler for statistics answers

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -199,7 +199,7 @@ function showStatsQuestion(id) {
   });
   const revealBtn = document.getElementById('sqRevealBtn');
   revealBtn.textContent = 'Reveal Answer';
-  revealBtn.addEventListener('click', () => revealStatsQuestion(q));
+  revealBtn.onclick = () => revealStatsQuestion(q);
 }
 
 const sqClose = document.getElementById('sqCloseBtn');


### PR DESCRIPTION
## Summary
- Avoid accumulating multiple handlers on the statistics modal's reveal button by assigning `onclick` rather than repeatedly adding listeners.

## Testing
- `npm test` *(fails: Error: no test specified)*
- Ran a small Node script with a minimal DOM stub to open several stats questions sequentially and confirmed the reveal button toggles from hidden to visible and back for each.


------
https://chatgpt.com/codex/tasks/task_e_688f6c124cf8832b9a246ac98f364178