### PR TITLE
feat: centralize PDF utilities and enable viewer globally

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -67,6 +67,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (container) container.classList.add('standalone');
   }
   populateBankSelects(bankFiles);
+  questionRenderer.initPdfViewer();
 });
 
 function loadQuestion() {
@@ -97,6 +98,7 @@ function startPractice() {
 function renderQuestion(q) {
   currentQuestion = q;
   selected = null;
+  questionRenderer.closePdf();
   document.getElementById('questionArea').style.display = 'block';
   const result = questionRenderer.renderQuestion(q, {
     text: '#qText',
@@ -110,6 +112,8 @@ function renderQuestion(q) {
     explanation: '#explanation',
     showInput: true
   });
+  questionRenderer.convertPdfLinks(document.getElementById('qText'));
+  questionRenderer.convertPdfLinks(document.getElementById('qTitle'));
   const options = document.getElementById('answerOptions');
   const calc = document.querySelector('.calculator');
   const input = document.getElementById('calcInput');
@@ -145,6 +149,7 @@ if (revealBtn) {
   revealBtn.addEventListener('click', function() {
     if (!currentQuestion) return;
     questionRenderer.revealAnswer(currentQuestion, { answer: '#answer', explanation: '#explanation' });
+    questionRenderer.convertPdfLinks(document.getElementById('explanation'));
   });
 }
 
@@ -187,6 +192,7 @@ function renderStats() {
 function showStatsQuestion(id) {
   const q = statsQuestions.find(x => String(x.id) === String(id));
   if (!q) return;
+  questionRenderer.closePdf();
   const overlay = document.getElementById('statsModal');
   overlay.style.display = 'flex';
   const result = questionRenderer.renderQuestion(q, {
@@ -200,6 +206,8 @@ function showStatsQuestion(id) {
     explanation: '#sqExplanation',
     showInput: true
   });
+  questionRenderer.convertPdfLinks(document.getElementById('sqText'));
+  questionRenderer.convertPdfLinks(document.getElementById('sqTitle'));
   if (result.buttons) result.buttons.forEach(btn => (btn.disabled = true));
   if (result.input) result.input.disabled = true;
   const revealBtn = document.getElementById('sqRevealBtn');
@@ -211,6 +219,7 @@ const sqClose = document.getElementById('sqCloseBtn');
 if (sqClose) {
   sqClose.addEventListener('click', () => {
     document.getElementById('statsModal').style.display = 'none';
+    questionRenderer.closePdf();
   });
 }
 
@@ -227,4 +236,5 @@ function revealStatsQuestion(q) {
   }
   questionRenderer.revealAnswer(q, { answer: ans, explanation: ex });
   btn.textContent = 'Hide Answer';
+  questionRenderer.convertPdfLinks(ex);
 }

--- a/static/practice.js
+++ b/static/practice.js
@@ -10,7 +10,6 @@ let bank;
 let questions = [], index = 0, selected = null, responses = [], reviewing = false;
 let backSummaryBtn, homeTopBtn, timerEl;
 let timerId, startTime;
-let pdfZoom = 1, pdfPane, pdfFrame;
 const flagged = new Set();
 let finished = false;
 let summaryData = null;
@@ -188,33 +187,10 @@ function updateNav() {
 
 
 
-function openPdf(url) {
-  pdfFrame.src = url;
-  pdfZoom = 1;
-  pdfFrame.style.transform = 'scale(1)';
-  pdfPane.style.display = 'flex';
-}
-
-function closePdf() {
-  pdfPane.style.display = 'none';
-  pdfFrame.src = '';
-}
-
-function convertPdfLinks(el) {
-  if (!el) return;
-  el.querySelectorAll('a[href$=".pdf"]').forEach(a => {
-    const btn = document.createElement('button');
-    btn.textContent = 'Open PDF';
-    btn.className = 'pdf-btn';
-    btn.onclick = (e) => { e.preventDefault(); openPdf(a.href); };
-    a.replaceWith(btn);
-  });
-}
-
 function renderQuestion() {
   const q = questions[index];
   selected = null;
-  closePdf();
+  questionRenderer.closePdf();
   document.querySelector('.q-number').textContent = `Question ${index + 1}`;
   const result = questionRenderer.renderQuestion(q, {
     text: '#qText',
@@ -227,8 +203,8 @@ function renderQuestion() {
     explanation: '#explanation',
     showInput: true
   });
-  convertPdfLinks(document.getElementById('qText'));
-  convertPdfLinks(document.getElementById('qTitle'));
+  questionRenderer.convertPdfLinks(document.getElementById('qText'));
+  questionRenderer.convertPdfLinks(document.getElementById('qTitle'));
   const opts = document.getElementById('answerOptions');
   const calc = document.querySelector('.calculator');
   const input = document.getElementById('calcInput');
@@ -270,7 +246,7 @@ function renderQuestion() {
       fb.className = '';
     }
     questionRenderer.revealAnswer(q, { answer: corr, explanation: expl, prefix: 'Correct answer' });
-    convertPdfLinks(expl);
+    questionRenderer.convertPdfLinks(expl);
     details.style.display = 'block';
   } else {
     const fb = document.getElementById('feedback');
@@ -308,7 +284,7 @@ function showSummary() {
   clearInterval(timerId);
   reviewing = false;
   finished = true;
-  closePdf();
+  questionRenderer.closePdf();
   backSummaryBtn.style.display = 'none';
   homeTopBtn.style.display = 'inline-block';
   document.querySelector('.main').style.display = 'none';
@@ -393,25 +369,14 @@ document.addEventListener('DOMContentLoaded', () => {
   backSummaryBtn = document.querySelector('.summary-btn');
   homeTopBtn = document.querySelector('.home-top-btn');
   timerEl = document.querySelector('.timer');
-  pdfPane = document.getElementById('pdfPane');
-  pdfFrame = document.getElementById('pdfFrame');
+  questionRenderer.initPdfViewer();
 
-  if (!backSummaryBtn || !homeTopBtn || !timerEl || !pdfPane || !pdfFrame) {
+  if (!backSummaryBtn || !homeTopBtn || !timerEl) {
     return;
   }
 
   backSummaryBtn.style.display = 'none';
   homeTopBtn.style.display = 'none';
-
-  document.querySelector('.pdf-close')?.addEventListener('click', closePdf);
-  document.querySelector('.pdf-zoom-in')?.addEventListener('click', () => {
-    pdfZoom += 0.1;
-    pdfFrame.style.transform = `scale(${pdfZoom})`;
-  });
-  document.querySelector('.pdf-zoom-out')?.addEventListener('click', () => {
-    pdfZoom = Math.max(0.1, pdfZoom - 0.1);
-    pdfFrame.style.transform = `scale(${pdfZoom})`;
-  });
 
   document.querySelector('.next-btn')?.addEventListener('click', () => {
     recordAnswer();

--- a/static/question.css
+++ b/static/question.css
@@ -56,3 +56,41 @@
   max-width: 100%;
   height: auto;
 }
+
+/* PDF viewer pane */
+.pdf-pane {
+  flex: 0 0 40%;
+  max-width: 40%;
+  display: none;
+  flex-direction: column;
+  height: 100%;
+  background: #fff;
+  border-right: 1px solid #ccc;
+}
+
+.pdf-controls {
+  padding: 5px;
+  background: #e5e9f0;
+  border-bottom: 1px solid #ccc;
+}
+
+.pdf-controls button {
+  margin-right: 5px;
+  padding: 4px 8px;
+}
+
+.pdf-wrapper {
+  flex: 1;
+  overflow: auto;
+}
+
+.pdf-btn {
+  margin-top: 10px;
+}
+
+#pdfFrame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  transform-origin: top left;
+}

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -225,7 +225,61 @@ function revealAnswer(question, targets) {
   return { answerText };
 }
 
-const questionRendererObj = { renderQuestion, updateStats, sanitize, evaluateAnswer, revealAnswer };
+// ----- PDF handling utilities -----
+let pdfPane, pdfFrame, pdfZoom = 1;
+
+function initPdfViewer() {
+  pdfPane = document.getElementById('pdfPane');
+  pdfFrame = document.getElementById('pdfFrame');
+  document.querySelector('.pdf-close')?.addEventListener('click', closePdf);
+  document.querySelector('.pdf-zoom-in')?.addEventListener('click', () => {
+    pdfZoom += 0.1;
+    if (pdfFrame) pdfFrame.style.transform = `scale(${pdfZoom})`;
+  });
+  document.querySelector('.pdf-zoom-out')?.addEventListener('click', () => {
+    pdfZoom = Math.max(0.1, pdfZoom - 0.1);
+    if (pdfFrame) pdfFrame.style.transform = `scale(${pdfZoom})`;
+  });
+}
+
+function openPdf(url) {
+  if (!pdfPane || !pdfFrame) initPdfViewer();
+  if (!pdfPane || !pdfFrame) return;
+  pdfFrame.src = url;
+  pdfZoom = 1;
+  pdfFrame.style.transform = 'scale(1)';
+  pdfPane.style.display = 'flex';
+}
+
+function closePdf() {
+  if (!pdfPane || !pdfFrame) initPdfViewer();
+  if (!pdfPane || !pdfFrame) return;
+  pdfPane.style.display = 'none';
+  pdfFrame.src = '';
+}
+
+function convertPdfLinks(el) {
+  if (!el) return;
+  el.querySelectorAll('a[href$=".pdf"]').forEach(a => {
+    const btn = document.createElement('button');
+    btn.textContent = 'Open PDF';
+    btn.className = 'pdf-btn';
+    btn.onclick = e => { e.preventDefault(); openPdf(a.href); };
+    a.replaceWith(btn);
+  });
+}
+
+const questionRendererObj = {
+  renderQuestion,
+  updateStats,
+  sanitize,
+  evaluateAnswer,
+  revealAnswer,
+  openPdf,
+  closePdf,
+  convertPdfLinks,
+  initPdfViewer
+};
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = questionRendererObj;
 } else {

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,6 +42,17 @@
         <div id="explanation"></div>
       </div>
 
+      <div class="pdf-pane" id="pdfPane" style="display:none">
+        <div class="pdf-controls">
+          <button type="button" class="pdf-zoom-in">+</button>
+          <button type="button" class="pdf-zoom-out">-</button>
+          <button type="button" class="pdf-close">&times;</button>
+        </div>
+        <div class="pdf-wrapper">
+          <iframe id="pdfFrame" src="" title="PDF viewer"></iframe>
+        </div>
+      </div>
+
       <div id="statsArea">
         <h2>Question Statistics</h2>
         <label for="statsBankSelect">Select Bank:</label>


### PR DESCRIPTION
## Summary
- move PDF link handling into question_renderer for reuse across pages
- invoke convertPdfLinks in practice and main flows and initialize shared PDF viewer
- add global PDF viewer markup and styles so PDFs open in-page across app

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f6f743908832bb83bfdd5b580a1ea