### PR TITLE
Render HTML links in answer options

### DIFF
--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -126,7 +126,8 @@ function renderQuestion(question, config) {
       if (optionsEl) {
         question.answers.forEach(a => {
           const btn = document.createElement('button');
-          btn.textContent = a.text;
+          btn.innerHTML = sanitize(a.text, true);
+          enhanceLinksAndImages(btn);
           btn.dataset.num = a.answer_number;
           optionsEl.appendChild(btn);
           buttons.push(btn);


### PR DESCRIPTION
## Summary
- sanitize answer option HTML and enhance links/images

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f77a22184832bbe87ce3353e072c8