### PR TITLE
Normalize newline spacing in question renderer

### DIFF
--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -3,6 +3,7 @@ function sanitize(text, inline) {
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
     .replace(/\u2028/g, '\n')
+    .replace(/\n{2,}/g, '\n')
     .replace(/\u00a0/g, ' ')
     .replace(/\u200b/g, '')
     .trim();


### PR DESCRIPTION
## Summary
- collapse consecutive newlines to a single newline during sanitization

## Testing
- `npm test` *(fails: no test specified)*
- `node -e "const fs=require('fs');const code=fs.readFileSync('static/question_renderer.js','utf8');eval(code);console.log(JSON.stringify(sanitize('Line1\n\nLine2\n\n\nLine3')));"`


------
https://chatgpt.com/codex/tasks/task_e_688f77a40df4832b8a9682c366c77b73