### PR TITLE
Persist last selected question bank

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -67,6 +67,18 @@ document.addEventListener('DOMContentLoaded', function() {
     if (container) container.classList.add('standalone');
   }
   populateBankSelects(bankFiles);
+  // Preselect the last used bank if available
+  try {
+    const last = localStorage.getItem('lastBank');
+    if (last) {
+      const bankSelect = document.getElementById('bankSelect');
+      if (bankSelect && bankFiles[last]) {
+        bankSelect.value = last;
+      }
+    }
+  } catch (e) {
+    console.warn('Failed to load lastBank', e);
+  }
   questionRenderer.initPdfViewer();
 });
 
@@ -91,6 +103,12 @@ function startPractice() {
   if (!num || num <= 0) {
     alert('Please enter a positive number of questions');
     return;
+  }
+  // Remember the chosen bank so it can be preselected next time
+  try {
+    localStorage.setItem('lastBank', data.bank);
+  } catch (e) {
+    console.warn('Failed to store lastBank', e);
   }
   window.location.href = `practice.html?bank=${encodeURIComponent(data.bank)}&num=${num}`;
 }

--- a/static/practice.js
+++ b/static/practice.js
@@ -422,6 +422,12 @@ document.addEventListener('DOMContentLoaded', () => {
     clearState();
     persistState = false;
     window.removeEventListener('beforeunload', saveState);
+    // Remember the bank so it can be preselected on the home page
+    try {
+      localStorage.setItem('lastBank', bank);
+    } catch (e) {
+      console.warn('Failed to store lastBank', e);
+    }
     window.location.href = 'index.html';
   });
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- Preselect last-used bank on load by reading from localStorage.
- Remember selected bank when starting practice or returning home.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f77a58f54832b8d8a04df0f930474