### PR TITLE
Handle block-level question titles

### DIFF
--- a/static/question.css
+++ b/static/question.css
@@ -1,4 +1,5 @@
 .question-title {
+  margin: 1em 0;
   font-weight: bold;
   font-size: 16pt;
 }

--- a/static/question_renderer.js
+++ b/static/question_renderer.js
@@ -85,7 +85,9 @@ function renderQuestion(question, config) {
   const showInput = config.showInput !== false;
 
   if (titleEl) {
-    const title = sanitize(question.title || '', true);
+    const rawTitle = question.title || '';
+    const needsBlock = /\n/.test(rawTitle) || /(^|\n)\s*\*\s/.test(rawTitle);
+    const title = sanitize(rawTitle, !needsBlock);
     if (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') {
       titleEl.innerHTML = title;
     } else {

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
 
       <div id="questionArea">
         <div id="qText"></div>
-        <p id="qTitle" class="question-title"></p>
+        <div id="qTitle" class="question-title"></div>
         <img id="qImg" alt="Question image">
         <div id="answerOptions" class="options"></div>
         <div class="calculator" style="display:none">

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -40,7 +40,7 @@
     <section class="question-area">
       <p class="q-number"></p>
       <div id="qText"></div>
-      <p id="qTitle" class="question-title"></p>
+      <div id="qTitle" class="question-title"></div>
       <div id="answerOptions" class="options"></div>
       <div class="calculator" style="display:none">
         <label>Answer</label>


### PR DESCRIPTION
## Summary
- Render block-level Markdown in question titles when needed
- Replace `<p id="qTitle">` with non-paragraph containers to prevent nested `<p>` tags
- Preserve question title spacing after element change

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f77a073d8832bae4046a9112aa684