### PR TITLE
refactor: centralize question types

### DIFF
--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -24,6 +24,15 @@ export interface QuestionBank {
   [key: string]: Question[][];
 }
 
+export interface BankData {
+  bank: string;
+  files: Question[][];
+}
+
+export interface BankLabels {
+  [key: string]: string;
+}
+
 // Global window interface extensions
 declare global {
   interface Window {
@@ -41,7 +50,7 @@ declare global {
     // Application state
     banks?: QuestionBank;
     populateBankSelects?: (banks: QuestionBank) => void;
-    questionRenderer?: any;
+    questionRenderer?: QuestionRenderer;
     toggleFlag?: (id: number) => boolean;
     practiceHistoryComponent?: any;
     // Timer functionality removed
@@ -57,14 +66,13 @@ export interface QuestionStats {
 }
 
 export interface PracticeState {
-  bank: string;
+  currentQuestion: number;
   questions: Question[];
-  currentIndex: number;
   answers: Record<number, string>;
   flagged: Set<number>;
   startTime: number;
-  endTime?: number;
-  isFinished: boolean;
+  bank: string;
+  totalQuestions: number;
 }
 
 // TimerStats interface removed - timer functionality no longer needed
@@ -74,22 +82,13 @@ export interface PracticeResult {
   bank: string;
   totalQuestions: number;
   correctAnswers: number;
-  wrongAnswers?: number;
-  notAnswered?: number;
   score: number;
-  startTime: number;
-  endTime: number;
-  duration: number; // in minutes
+  duration: number;
   date: string;
   flaggedQuestions: number;
-  // timerStats removed - no longer tracking timer statistics
-  questions: {
-    id: number;
-    userAnswer: string;
-    correctAnswer: string;
-    isCorrect: boolean;
-    flagged: boolean;
-  }[];
+  questions: Question[];
+  answers: Record<number, string>;
+  flagged: number[];
 }
 
 export interface PracticeHistory {
@@ -101,13 +100,19 @@ export interface PracticeHistory {
 }
 
 export interface RenderOptions {
-  text: string;
-  options: string;
-  input: string;
-  unit: string;
-  feedback: string;
-  answer: string;
-  explanation: string;
-  showInput: boolean;
-  title?: string; // Add missing title property
+  text?: string;
+  title?: string;
+  img?: string;
+  options?: string;
+  input?: string;
+  unit?: string;
+  feedback?: string;
+  answer?: string;
+  explanation?: string;
+  showInput?: boolean;
+}
+
+export interface QuestionRenderer {
+  initPdfViewer(): void;
+  renderQuestion(question: Question, config?: RenderOptions): void;
 }

--- a/static/main.ts
+++ b/static/main.ts
@@ -1,34 +1,9 @@
-// Type definitions moved inline to avoid import issues
-
-interface Question {
-  id: number;
-  bank: string;
-  title: string;
-  text: string;
-  why: string;
-  resource_image?: string | null;
-  visible: boolean;
-  is_calculation: boolean;
-  correct_answer: string;
-  answer_unit?: string;
-  correct_answer_number?: number | null;
-  weighting?: number | null;
-  answers: Array<{text: string; answer_number: number}>;
-  is_free: boolean;
-}
-
-interface QuestionBank {
-  [key: string]: Question[][];
-}
-
-interface BankData {
-  bank: string;
-  files: Question[][];
-}
-
-interface BankLabels {
-  [key: string]: string;
-}
+import type {
+  Question,
+  QuestionBank,
+  BankData,
+  BankLabels,
+} from '@/types/question';
 
 let bankFiles: QuestionBank = (window as any).banks || {};
 const flagged = new Set<number>();

--- a/static/practice.ts
+++ b/static/practice.ts
@@ -1,36 +1,10 @@
 // Practice Mode Logic - Full Implementation
-// Type definitions moved inline to avoid import issues
 
-interface Question {
-  id: number;
-  bank: string;
-  title: string;
-  text: string;
-  why: string;
-  resource_image?: string | null;
-  visible: boolean;
-  is_calculation: boolean;
-  correct_answer: string;
-  answer_unit?: string;
-  correct_answer_number?: number | null;
-  weighting?: number | null;
-  answers: Array<{text: string; answer_number: number}>;
-  is_free: boolean;
-}
-
-// QuestionBank interface removed - defined globally in types/question.ts
-
-interface PracticeState {
-  currentQuestion: number;
-  questions: Question[];
-  answers: { [key: number]: string };
-  flagged: Set<number>;
-  startTime: number;
-  bank: string;
-  totalQuestions: number;
-}
-
-// Timer functionality removed
+import type {
+  Question,
+  PracticeState,
+  PracticeResult,
+} from '@/types/question';
 
 // Timer functionality removed - practice mode runs without time constraints
 
@@ -494,7 +468,7 @@ class PracticeManager {
       questions: this.state.questions,
       answers: this.state.answers,
       flagged: Array.from(this.state.flagged)
-    });
+    } as PracticeResult);
 
     this.isFinished = true;
     
@@ -597,7 +571,7 @@ class PracticeManager {
     // This method is no longer needed as review functionality is moved to summary.ts
   }
 
-  private savePracticeResult(result: any): void {
+  private savePracticeResult(result: PracticeResult): void {
     try {
       const existingHistory = localStorage.getItem('practice_history');
       const history = existingHistory ? JSON.parse(existingHistory) : { results: [] };

--- a/static/question_renderer.ts
+++ b/static/question_renderer.ts
@@ -1,33 +1,8 @@
-interface Question {
-  id: number;
-  text: string;
-  title: string;
-  answers: { text: string; answer_number: number; }[];
-  is_calculation: boolean;
-  answer_unit?: string;
-  resource_image?: string | null | undefined;
-  explanation?: string;
-  correct_answer: string;
-  correct_answer_number?: number | null | undefined;
-}
-
-interface RenderConfig {
-  text?: string;
-  title?: string;
-  img?: string;
-  options?: string;
-  input?: string;
-  unit?: string;
-  feedback?: string;
-  answer?: string;
-  explanation?: string;
-  showInput?: boolean;
-}
-
-interface QuestionRenderer {
-  initPdfViewer(): void;
-  renderQuestion(question: Question, config?: RenderConfig): void;
-}
+import type {
+  Question,
+  RenderOptions,
+  QuestionRenderer,
+} from '@/types/question';
 
 function sanitize(content: string, inline: boolean = false): string {
   if (typeof (window as any).DOMPurify !== 'undefined' && typeof (window as any).marked !== 'undefined') {
@@ -66,7 +41,7 @@ function enhanceLinksAndImages(element: HTMLElement): void {
 }
 
 // Main render function
-function renderQuestion(question: Question, config: RenderConfig = {}): void {
+function renderQuestion(question: Question, config: RenderOptions = {}): void {
   const {
     text: textSelector = '#questionText',
     title: titleSelector = '#questionTitle',

--- a/static/summary.ts
+++ b/static/summary.ts
@@ -1,38 +1,9 @@
 // Summary Page Logic - Dedicated Implementation
 
-interface Question {
-  id: number;
-  bank: string;
-  title: string;
-  text: string;
-  why: string;
-  resource_image?: string | null;
-  visible: boolean;
-  is_calculation: boolean;
-  correct_answer: string;
-  answer_unit?: string;
-  correct_answer_number?: number | null;
-  weighting?: number | null;
-  answers: Array<{text: string; answer_number: number}>;
-  is_free: boolean;
-}
-
-interface TestResult {
-  id: string;
-  bank: string;
-  totalQuestions: number;
-  correctAnswers: number;
-  score: number;
-  duration: number;
-  date: string;
-  flaggedQuestions: number;
-  questions: Question[];
-  answers: { [key: number]: string };
-  flagged: number[];
-}
+import type { Question, PracticeResult } from '@/types/question';
 
 class SummaryManager {
-  private testResult: TestResult | null = null;
+  private testResult: PracticeResult | null = null;
   private currentReviewQuestion: number = 0;
   private reviewMode: 'all' | 'incorrect' | 'flagged' = 'all';
 
@@ -264,7 +235,6 @@ class SummaryManager {
     this.currentReviewQuestion = questionNum;
     const question = this.testResult.questions[questionNum];
     const userAnswer = this.testResult.answers[questionNum] || 'No answer';
-    const isCorrect = userAnswer !== 'No answer' && this.evaluateAnswer(question, userAnswer);
 
     // Update modal title
     const modalTitle = document.getElementById('reviewQuestionTitle');
@@ -370,7 +340,7 @@ class SummaryManager {
 // Initialize summary manager when DOM is ready
 document.addEventListener('DOMContentLoaded', function() {
   console.log('Summary page initializing...');
-  const summaryManager = new SummaryManager();
+  new SummaryManager();
 });
 
 // Make class available globally if needed

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,12 +25,12 @@
   },
   "include": [
     "src/**/*",
+    "static/**/*",
     "vite.config.ts"
   ],
   "exclude": [
     "node_modules",
     "dist",
-    "static",
     "templates",
     "question_banks"
   ]


### PR DESCRIPTION
## Summary
- consolidate `Question`-related interfaces into `src/types/question.ts`
- replace inline type declarations in static modules with shared imports
- enable static modules to resolve shared types via updated `tsconfig` paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: TS errors in static files and missing Node types)*

------
https://chatgpt.com/codex/tasks/task_e_68a9db929da8832bad7b6a0358e5ff34