### PR TITLE
refactor: centralize bank name mapping

### DIFF
--- a/src/components/practiceHistory.js
+++ b/src/components/practiceHistory.js
@@ -1,4 +1,6 @@
 // Practice History Component - JavaScript Version
+import { formatBankName } from '../utils/bankNames';
+
 class PracticeHistoryComponent {
   constructor() {
     this.container = null;
@@ -93,7 +95,7 @@ class PracticeHistoryComponent {
     return `
       <div class="result-card" data-result-id="${result.id}">
         <div class="result-header">
-          <div class="result-bank">${this.formatBankName(result.bank)}</div>
+          <div class="result-bank">${formatBankName(result.bank)}</div>
           <div class="result-date">${date} at ${time}</div>
         </div>
         <div class="result-details">
@@ -125,17 +127,6 @@ class PracticeHistoryComponent {
         </div>
       </div>
     `;
-  }
-
-  formatBankName(bank) {
-    const bankNames = {
-      'calculations': 'Calculations',
-      'clinical_mep': 'Clinical MEP',
-      'clinical_mixed': 'Clinical Mixed',
-      'clinical_otc': 'Clinical OTC',
-      'clinical_therapeutics': 'Clinical Therapeutics'
-    };
-    return bankNames[bank] || bank;
   }
 
   attachEventListeners() {
@@ -226,7 +217,7 @@ class PracticeHistoryComponent {
             <div class="summary-stats">
               <div class="summary-stat">
                 <span class="stat-label">Bank:</span>
-                <span class="stat-value">${this.formatBankName(result.bank)}</span>
+                <span class="stat-value">${formatBankName(result.bank)}</span>
               </div>
               <div class="summary-stat">
                 <span class="stat-label">Score:</span>

--- a/src/utils/bankNames.ts
+++ b/src/utils/bankNames.ts
@@ -1,0 +1,14 @@
+import type { BankLabels } from '@/types/question';
+
+export const bankNames: BankLabels = {
+  calculations: 'Calculations',
+  clinical_mep: 'Clinical MEP',
+  clinical_mixed: 'Clinical Mixed',
+  clinical_otc: 'Clinical OTC',
+  clinical_therapeutics: 'Clinical Therapeutics'
+};
+
+export function formatBankName(bank: string): string {
+  return bankNames[bank] || bank;
+}
+

--- a/static/main.ts
+++ b/static/main.ts
@@ -2,20 +2,13 @@ import type {
   Question,
   QuestionBank,
   BankData,
-  BankLabels,
 } from '@/types/question';
+import { formatBankName } from '@/utils/bankNames';
 
 let bankFiles: QuestionBank = (window as any).banks || {};
 const flagged = new Set<number>();
 let banksPopulated = false;
 
-const bankLabels: BankLabels = {
-  calculations: 'Calculations',
-  clinical_mep: 'Clinical MEP',
-  clinical_mixed: 'Clinical Mixed',
-  clinical_otc: 'Clinical OTC',
-  clinical_therapeutics: 'Clinical Therapeutics'
-};
 
 const loadBtn = document.getElementById('loadBtn') as HTMLButtonElement | null;
 if (loadBtn) {loadBtn.addEventListener('click', loadQuestion);}
@@ -61,14 +54,14 @@ function populateBankSelects(data: QuestionBank): void {
     if (bankSelect) {
       const opt1 = document.createElement('option');
       opt1.value = name;
-      opt1.textContent = bankLabels[name] || name;
+      opt1.textContent = formatBankName(name);
       bankSelect.appendChild(opt1);
       console.log('Added option:', name);
     }
     if (statsSelect) {
       const opt2 = document.createElement('option');
       opt2.value = name;
-      opt2.textContent = bankLabels[name] || name;
+      opt2.textContent = formatBankName(name);
       statsSelect.appendChild(opt2);
     }
   });

--- a/static/practice.ts
+++ b/static/practice.ts
@@ -5,6 +5,7 @@ import type {
   PracticeState,
   PracticeResult,
 } from '@/types/question';
+import { formatBankName } from '@/utils/bankNames';
 
 // Timer functionality removed - practice mode runs without time constraints
 
@@ -83,7 +84,7 @@ class PracticeManager {
   // Update UI
     const titleEl = document.querySelector('.test-title');
     if (titleEl) {
-      titleEl.textContent = `${this.formatBankName(bank)} - ${selectedQuestions.length} Questions`;
+      titleEl.textContent = `${formatBankName(bank)} - ${selectedQuestions.length} Questions`;
     }
 
     this.setupNavigation();
@@ -216,17 +217,6 @@ class PracticeManager {
     this.updateNavigation();
     this.updateProgress();
     this.saveSession(); // Auto-save on question change
-  }
-
-  private formatBankName(bank: string): string {
-    const bankNames: { [key: string]: string } = {
-      'calculations': 'Calculations',
-      'clinical_mep': 'Clinical MEP',
-      'clinical_mixed': 'Clinical Mixed',
-      'clinical_otc': 'Clinical OTC',
-      'clinical_therapeutics': 'Clinical Therapeutics'
-    };
-    return bankNames[bank] || bank;
   }
 
   private saveAnswer(): void {
@@ -657,7 +647,7 @@ class PracticeManager {
       // Update UI
       const titleEl = document.querySelector('.test-title');
       if (titleEl) {
-        titleEl.textContent = `${this.formatBankName(data.bank)} - ${questions.length} Questions`;
+        titleEl.textContent = `${formatBankName(data.bank)} - ${questions.length} Questions`;
       }
       
       this.setupNavigation();


### PR DESCRIPTION
## Summary
- add shared bank name map and formatter
- use shared mapping in main, practice flow, and practice history components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: static/practice.ts parameter implicit any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dd0d2058832b924ed0c655f7c23b