### PR TITLE
refactor: centralize empty history constant

### DIFF
--- a/src/components/practiceHistory.js
+++ b/src/components/practiceHistory.js
@@ -1,5 +1,6 @@
 // Practice History Component - JavaScript Version
 import { formatBankName } from '../utils/bankNames';
+import { EMPTY_HISTORY } from '../utils/history';
 
 class PracticeHistoryComponent {
   constructor() {
@@ -262,26 +263,14 @@ class PracticeHistoryComponent {
     try {
       const history = localStorage.getItem('practice_history');
       if (!history) {
-        return {
-          results: [],
-          totalTests: 0,
-          averageScore: 0,
-          bestScore: 0,
-          totalTime: 0
-        };
+        return { ...EMPTY_HISTORY };
       }
 
       const parsedHistory = JSON.parse(history);
       return this.calculateHistoryStats(parsedHistory.results || []);
     } catch (error) {
       console.warn('Failed to load practice history:', error);
-      return {
-        results: [],
-        totalTests: 0,
-        averageScore: 0,
-        bestScore: 0,
-        totalTime: 0
-      };
+      return { ...EMPTY_HISTORY };
     }
   }
 
@@ -304,6 +293,7 @@ class PracticeHistoryComponent {
   clearPracticeHistory() {
     try {
       localStorage.removeItem('practice_history');
+      this.history = { ...EMPTY_HISTORY };
     } catch (error) {
       console.warn('Failed to clear practice history:', error);
     }

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,0 +1,9 @@
+import type { PracticeHistory } from '@/types/question';
+
+export const EMPTY_HISTORY: PracticeHistory = {
+  results: [],
+  totalTests: 0,
+  averageScore: 0,
+  bestScore: 0,
+  totalTime: 0
+};

--- a/static/practice.ts
+++ b/static/practice.ts
@@ -6,6 +6,7 @@ import type {
   PracticeResult,
 } from '@/types/question';
 import { formatBankName } from '@/utils/bankNames';
+import { EMPTY_HISTORY } from '@/utils/history';
 
 // Timer functionality removed - practice mode runs without time constraints
 
@@ -564,7 +565,7 @@ class PracticeManager {
   private savePracticeResult(result: PracticeResult): void {
     try {
       const existingHistory = localStorage.getItem('practice_history');
-      const history = existingHistory ? JSON.parse(existingHistory) : { results: [] };
+      const history = existingHistory ? JSON.parse(existingHistory) : { ...EMPTY_HISTORY };
       
       history.results.unshift(result);
       

--- a/static/summary.ts
+++ b/static/summary.ts
@@ -1,6 +1,7 @@
 // Summary Page Logic - Dedicated Implementation
 
 import type { Question, PracticeResult } from '@/types/question';
+import { EMPTY_HISTORY } from '@/utils/history';
 
 class SummaryManager {
   private testResult: PracticeResult | null = null;
@@ -28,7 +29,7 @@ class SummaryManager {
 
     try {
       const existingHistory = localStorage.getItem('practice_history');
-      const history = existingHistory ? JSON.parse(existingHistory) : { results: [] };
+      const history = existingHistory ? JSON.parse(existingHistory) : { ...EMPTY_HISTORY };
       
       const result = history.results.find((r: any) => r.id === resultId);
       if (!result) {


### PR DESCRIPTION
## Summary
- define reusable `EMPTY_HISTORY` constant for practice history defaults
- use shared constant when loading, saving, and clearing practice history

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check` *(fails: cannot find module 'path' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e104376c832ba156968ea29f6fa8