### PR TITLE
Refactor back-to-summary handler into reusable helper

### DIFF
--- a/src/components/practiceHistory.js
+++ b/src/components/practiceHistory.js
@@ -177,6 +177,17 @@ class PracticeHistoryComponent {
     });
   }
 
+  attachBackToSummary() {
+    if (!this.container) { return; }
+
+    const backBtn = this.container.querySelector('#backToSummary');
+    if (backBtn) {
+      backBtn.addEventListener('click', () => {
+        this.render(this.container.id);
+      });
+    }
+  }
+
   showAllResultsModal() {
     // Simplified: just show all results in the main area
     if (this.container) {
@@ -191,14 +202,8 @@ class PracticeHistoryComponent {
           </div>
         </div>
       `;
-      
-      // Add back button functionality
-      const backBtn = this.container.querySelector('#backToSummary');
-      if (backBtn) {
-        backBtn.addEventListener('click', () => {
-          this.render(this.container.id);
-        });
-      }
+
+      this.attachBackToSummary();
     }
   }
 
@@ -247,14 +252,8 @@ class PracticeHistoryComponent {
           </div>
         </div>
       `;
-      
-      // Add back button functionality
-      const backBtn = this.container.querySelector('#backToSummary');
-      if (backBtn) {
-        backBtn.addEventListener('click', () => {
-          this.render(this.container.id);
-        });
-      }
+
+      this.attachBackToSummary();
     }
   }
 


### PR DESCRIPTION
## Summary
- add attachBackToSummary helper to bind the summary back button
- invoke helper from showAllResultsModal and showResultDetails to remove duplicated code

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9e1d30f34832bb20beba6c96c31bf