### PR TITLE
refactor: unify practice header buttons

### DIFF
--- a/src/styles/consolidated.css
+++ b/src/styles/consolidated.css
@@ -192,6 +192,17 @@ body {
   border-color: #059669;
 }
 
+.btn-warning {
+  background-color: var(--color-warning);
+  color: var(--color-white);
+  border-color: var(--color-warning);
+}
+
+.btn-warning:hover:not(:disabled) {
+  background-color: #d97706;
+  border-color: #d97706;
+}
+
 .btn-danger {
   background-color: var(--color-error);
   color: var(--color-white);

--- a/src/styles/practice.css
+++ b/src/styles/practice.css
@@ -26,42 +26,7 @@
 
 /* Timer styles removed */
 
-.finish-btn {
-  background: #e74c3c;
-  color: #ffffff;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 6px;
-  cursor: pointer;
-  margin-right: 10px;
-  font-size: 16px;
-  font-weight: 600;
-  transition: all 0.2s ease;
-}
-
-.finish-btn:hover {
-  background: #c0392b;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
-.summary-btn,
-.home-top-btn {
-  background: #f39c12;
-  color: #ffffff;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 6px;
-  cursor: pointer;
-  margin-right: 10px;
-  font-size: 16px;
-  font-weight: 600;
-  transition: all 0.2s ease;
-}
-
-.summary-btn:hover,
-.home-top-btn:hover {
-  background: #e67e22;
+.header-right .btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
@@ -713,6 +678,7 @@
 .header-right {
   display: flex;
   align-items: center;
+  gap: 10px;
 }
 
 /* PDF viewer pane */

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -19,9 +19,9 @@
       </div>
       <!-- Timer removed -->
       <div class="header-right">
-        <button type="button" class="summary-btn" style="display:none">Summary</button>
-        <button type="button" class="home-top-btn" style="display:none">Home</button>
-        <button type="button" class="finish-btn">Finish Test</button>
+        <button type="button" class="btn btn-warning" style="display:none">Summary</button>
+        <button type="button" class="btn btn-warning" style="display:none">Home</button>
+        <button type="button" class="btn btn-danger finish-btn">Finish Test</button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace `.summary-btn` and `.home-top-btn` with shared `.btn btn-warning`
- move hover/spacing styles to header container and add `.btn-warning` variant
- remove redundant button styles from practice page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: TS2669 Augmentations for the global scope can only be directly nested...)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e25be040832bb67d19b20b3a6218