### PR TITLE
refactor: streamline console logging

### DIFF
--- a/static/banks.ts
+++ b/static/banks.ts
@@ -11,34 +11,33 @@ declare global {
 }
 
 function initializeBanks(): void {
-  console.log('Initializing banks...');
-  console.log('window.calculations:', window.calculations);
-  console.log('window.clinicalMepLow:', window.clinicalMepLow);
-  
   const banks: QuestionBank = {
     calculations: [window.calculations || []],
     clinical_mep: [window.clinicalMepLow || []],
-    clinical_mixed: [window.clinicalMixedHigh || [], window.clinicalMixedLow || [], window.clinicalMixedMedium || []],
+    clinical_mixed: [
+      window.clinicalMixedHigh || [],
+      window.clinicalMixedLow || [],
+      window.clinicalMixedMedium || [],
+    ],
     clinical_otc: [window.clinicalOtcLow || []],
-    clinical_therapeutics: [window.clinicalTherapeuticsHigh || [], window.clinicalTherapeuticsLow || [], window.clinicalTherapeuticsMedium || []]
+    clinical_therapeutics: [
+      window.clinicalTherapeuticsHigh || [],
+      window.clinicalTherapeuticsLow || [],
+      window.clinicalTherapeuticsMedium || [],
+    ],
   };
-
-  console.log('Banks object:', banks);
   window.banks = banks;
-  
+
   // Try to populate banks immediately if function is available
   if (window.populateBankSelects) {
-    console.log('Calling populateBankSelects immediately...');
     window.populateBankSelects(banks);
   } else {
-    console.log('populateBankSelects not available yet, will retry...');
     // Retry after a short delay to allow main.ts to load
     setTimeout(() => {
       if (window.populateBankSelects) {
-        console.log('Calling populateBankSelects after delay...');
         window.populateBankSelects(banks);
       } else {
-        console.log('populateBankSelects still not available');
+        console.warn('populateBankSelects not available');
       }
     }, 100);
   }

--- a/static/main.ts
+++ b/static/main.ts
@@ -1,62 +1,67 @@
-import type {
-  Question,
-  QuestionBank,
-  BankData,
-} from '@/types/question';
+import type { Question, QuestionBank, BankData } from '@/types/question';
 import { formatBankName } from '@/utils/bankNames';
 
 let bankFiles: QuestionBank = (window as any).banks || {};
 const flagged = new Set<number>();
 let banksPopulated = false;
 
-
 const loadBtn = document.getElementById('loadBtn') as HTMLButtonElement | null;
-if (loadBtn) {loadBtn.addEventListener('click', loadQuestion);}
+if (loadBtn) {
+  loadBtn.addEventListener('click', loadQuestion);
+}
 
-const practiceBtn = document.getElementById('practiceBtn') as HTMLButtonElement | null;
-if (practiceBtn) {practiceBtn.addEventListener('click', startPractice);}
+const practiceBtn = document.getElementById(
+  'practiceBtn'
+) as HTMLButtonElement | null;
+if (practiceBtn) {
+  practiceBtn.addEventListener('click', startPractice);
+}
 
 // Add event handlers for question buttons
 let currentQuestion: Question | null = null;
 
-const checkBtn = document.getElementById('checkBtn') as HTMLButtonElement | null;
-if (checkBtn) {checkBtn.addEventListener('click', checkAnswer);}
+const checkBtn = document.getElementById(
+  'checkBtn'
+) as HTMLButtonElement | null;
+if (checkBtn) {
+  checkBtn.addEventListener('click', checkAnswer);
+}
 
-const revealBtn = document.getElementById('revealBtn') as HTMLButtonElement | null;
-if (revealBtn) {revealBtn.addEventListener('click', revealAnswer);}
-
-
+const revealBtn = document.getElementById(
+  'revealBtn'
+) as HTMLButtonElement | null;
+if (revealBtn) {
+  revealBtn.addEventListener('click', revealAnswer);
+}
 
 function populateBankSelects(data: QuestionBank): void {
-  console.log('populateBankSelects called with:', data);
-  
   // Prevent duplicate population
   if (banksPopulated) {
-    console.log('Banks already populated, skipping...');
     return;
   }
-  
-  const bankSelect = document.getElementById('bankSelect') as HTMLSelectElement | null;
-  const statsSelect = document.getElementById('statsBankSelect') as HTMLSelectElement | null;
-  
+
+  const bankSelect = document.getElementById(
+    'bankSelect'
+  ) as HTMLSelectElement | null;
+  const statsSelect = document.getElementById(
+    'statsBankSelect'
+  ) as HTMLSelectElement | null;
+
   if (!bankSelect && !statsSelect) {
-    console.log('Bank select elements not found');
+    console.warn('Bank select elements not found');
     return;
   }
-  
+
   const names = Object.keys(data)
     .filter(k => Array.isArray(data[k]))
     .sort();
-    
-  console.log('Bank names found:', names);
-    
+
   names.forEach(name => {
     if (bankSelect) {
       const opt1 = document.createElement('option');
       opt1.value = name;
       opt1.textContent = formatBankName(name);
       bankSelect.appendChild(opt1);
-      console.log('Added option:', name);
     }
     if (statsSelect) {
       const opt2 = document.createElement('option');
@@ -65,22 +70,27 @@ function populateBankSelects(data: QuestionBank): void {
       statsSelect.appendChild(opt2);
     }
   });
-  
+
   // Mark as populated to prevent duplicates
   banksPopulated = true;
-  console.log('Banks population completed');
 }
 
 function getSelectedBank(id: string): BankData | null {
   const sel = document.getElementById(id) as HTMLSelectElement | null;
-  if (!sel) {return null;}
-  
+  if (!sel) {
+    return null;
+  }
+
   const bank = sel.value;
-  if (!bank) {return null;}
-  
+  if (!bank) {
+    return null;
+  }
+
   const files = bankFiles[bank];
-  if (!Array.isArray(files) || !files.length) {return null;}
-  
+  if (!Array.isArray(files) || !files.length) {
+    return null;
+  }
+
   return { bank, files };
 }
 
@@ -97,37 +107,39 @@ function toggleFlag(id: number): boolean {
 
 // Make populateBankSelects available globally
 (window as any).populateBankSelects = populateBankSelects;
-console.log('main.ts loaded, populateBankSelects exposed globally');
 
 // Adjust layout when loaded in standalone mode
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
   // Ensure statsModal is hidden by default
   const statsModal = document.getElementById('statsModal');
   if (statsModal) {
     statsModal.classList.remove('show');
   }
-  
+
   const params = new URLSearchParams(window.location.search);
   if (params.get('isStandAlone') === 'true') {
     document.body.classList.add('standalone');
     const container = document.querySelector('.container');
-    if (container) {container.classList.add('standalone');}
+    if (container) {
+      container.classList.add('standalone');
+    }
   }
-  
+
   // Update bankFiles if banks have been loaded
   if ((window as any).banks) {
     bankFiles = (window as any).banks;
-    console.log('Banks found in window, populating selects...');
     populateBankSelects(bankFiles);
   } else {
-    console.log('No banks found in window yet');
+    console.warn('No banks found in window yet');
   }
-  
+
   // Preselect the last used bank if available
   try {
     const last = localStorage.getItem('lastBank');
     if (last) {
-      const bankSelect = document.getElementById('bankSelect') as HTMLSelectElement | null;
+      const bankSelect = document.getElementById(
+        'bankSelect'
+      ) as HTMLSelectElement | null;
       if (bankSelect && bankFiles[last]) {
         bankSelect.value = last;
       }
@@ -135,7 +147,7 @@ document.addEventListener('DOMContentLoaded', function() {
   } catch (e) {
     console.warn('Failed to load lastBank', e);
   }
-  
+
   if ((window as any).questionRenderer) {
     (window as any).questionRenderer.initPdfViewer();
   }
@@ -147,7 +159,7 @@ function loadQuestion(): void {
     alert('Please select a question bank');
     return;
   }
-  
+
   const qs = data.files[Math.floor(Math.random() * data.files.length)];
   const q = qs[Math.floor(Math.random() * qs.length)];
   renderQuestion(q);
@@ -156,17 +168,19 @@ function loadQuestion(): void {
 function renderQuestion(question: Question): void {
   // Store current question for button actions
   currentQuestion = question;
-  
+
   // Store the selected bank for next time
   try {
-    const bankSelect = document.getElementById('bankSelect') as HTMLSelectElement | null;
+    const bankSelect = document.getElementById(
+      'bankSelect'
+    ) as HTMLSelectElement | null;
     if (bankSelect && bankSelect.value) {
       localStorage.setItem('lastBank', bankSelect.value);
     }
   } catch (e) {
     console.warn('Failed to save lastBank', e);
   }
-  
+
   // Render the question using the question renderer
   if ((window as any).questionRenderer) {
     (window as any).questionRenderer.renderQuestion(question, {
@@ -178,16 +192,16 @@ function renderQuestion(question: Question): void {
       unit: '#answerUnit',
       feedback: '#feedback',
       answer: '#answer',
-      explanation: '#explanation'
+      explanation: '#explanation',
     });
   }
-  
+
   // Show the question area
   const questionArea = document.getElementById('questionArea');
   if (questionArea) {
     questionArea.style.display = 'block';
   }
-  
+
   // Reset feedback
   const feedbackEl = document.getElementById('feedback');
   if (feedbackEl) {
@@ -202,15 +216,15 @@ function startPractice(): void {
     alert('Please select a question bank');
     return;
   }
-  
+
   // Get number of questions
   const numInput = document.getElementById('numInput') as HTMLInputElement;
   const numQuestions = numInput ? parseInt(numInput.value) || 10 : 10;
-  
+
   // Check for existing session
   const sessionKey = `practice_session_${data.bank}_${numQuestions}`;
   const existingSession = sessionStorage.getItem(sessionKey);
-  
+
   if (existingSession) {
     const confirmResume = confirm(
       'You have an unfinished practice session for this bank. Would you like to resume where you left off?'
@@ -223,14 +237,14 @@ function startPractice(): void {
       sessionStorage.removeItem(sessionKey);
     }
   }
-  
+
   // Store the selected bank for next time
   try {
     localStorage.setItem('lastBank', data.bank);
   } catch (e) {
     console.warn('Failed to save lastBank', e);
   }
-  
+
   // Redirect to practice page with bank and number parameters
   window.location.href = `practice.html?bank=${encodeURIComponent(data.bank)}&num=${numQuestions}`;
 }
@@ -239,10 +253,10 @@ function checkAnswer(): void {
   if (!currentQuestion) {
     return;
   }
-  
+
   // Get user answer first
   let userAnswer = '';
-  
+
   if (currentQuestion.is_calculation) {
     const calcInput = document.getElementById('calcInput') as HTMLInputElement;
     if (!calcInput || !calcInput.value) {
@@ -251,14 +265,16 @@ function checkAnswer(): void {
     }
     userAnswer = calcInput.value;
   } else {
-    const selectedOption = document.querySelector('input[name="answer"]:checked') as HTMLInputElement;
+    const selectedOption = document.querySelector(
+      'input[name="answer"]:checked'
+    ) as HTMLInputElement;
     if (!selectedOption) {
       alert('Please select an answer first');
       return;
     }
     userAnswer = selectedOption.value;
   }
-  
+
   const isCorrect = evaluateAnswer(currentQuestion, userAnswer);
   revealAnswerWithFeedback(currentQuestion, isCorrect);
 }
@@ -269,20 +285,24 @@ function evaluateAnswer(question: Question, userAnswer: string): boolean {
   }
 
   if (question.is_free) {
-    return userAnswer.toLowerCase().trim() === question.correct_answer.toLowerCase().trim();
+    return (
+      userAnswer.toLowerCase().trim() ===
+      question.correct_answer.toLowerCase().trim()
+    );
   }
-  
+
   if (question.is_calculation) {
     const userNum = parseFloat(userAnswer);
-    const correctNum = question.correct_answer_number || parseFloat(question.correct_answer);
+    const correctNum =
+      question.correct_answer_number || parseFloat(question.correct_answer);
     if (isNaN(userNum) || isNaN(correctNum)) {
       return false;
     }
-    
+
     const tolerance = Math.abs(correctNum * 0.05); // 5% tolerance
     return Math.abs(userNum - correctNum) <= tolerance;
   }
-  
+
   // Multiple choice - use correct_answer_number directly
   const correctAnswerNumber = question.correct_answer_number;
   if (correctAnswerNumber === undefined || correctAnswerNumber === null) {
@@ -291,25 +311,36 @@ function evaluateAnswer(question: Question, userAnswer: string): boolean {
   return parseInt(userAnswer) === correctAnswerNumber;
 }
 
-function revealAnswerWithFeedback(question: Question, isCorrect: boolean): void {
+function revealAnswerWithFeedback(
+  question: Question,
+  isCorrect: boolean
+): void {
   const feedbackEl = document.getElementById('feedback');
   const answerEl = document.getElementById('answer');
   const explanationEl = document.getElementById('explanation');
 
   if (feedbackEl) {
     feedbackEl.textContent = isCorrect ? 'Correct!' : 'Incorrect';
-    feedbackEl.className = isCorrect ? 'feedback correct' : 'feedback incorrect';
+    feedbackEl.className = isCorrect
+      ? 'feedback correct'
+      : 'feedback incorrect';
   }
 
   if (answerEl) {
     let correctAnswerText = question.correct_answer;
-    
+
     // For multiple choice questions, find the correct answer text
-    if (!correctAnswerText && question.correct_answer_number && question.answers) {
-      const correctAnswer = question.answers.find(a => a.answer_number === question.correct_answer_number);
+    if (
+      !correctAnswerText &&
+      question.correct_answer_number &&
+      question.answers
+    ) {
+      const correctAnswer = question.answers.find(
+        a => a.answer_number === question.correct_answer_number
+      );
       correctAnswerText = correctAnswer ? correctAnswer.text : 'N/A';
     }
-    
+
     answerEl.innerHTML = `<strong>Correct Answer:</strong> ${correctAnswerText || 'N/A'}${question.answer_unit ? ' ' + question.answer_unit : ''}`;
     answerEl.style.display = 'block';
   }
@@ -324,10 +355,10 @@ function revealAnswer(): void {
   if (!currentQuestion) {
     return;
   }
-  
+
   // Use the same rendering logic but without feedback
   revealAnswerWithFeedback(currentQuestion, false);
-  
+
   // Clear any existing feedback since this is just revealing the answer
   const feedbackEl = document.getElementById('feedback');
   if (feedbackEl) {
@@ -335,8 +366,6 @@ function revealAnswer(): void {
     feedbackEl.className = 'feedback';
   }
 }
-
-
 
 // Functions are available globally via window object
 // No need to export since we're not using ES modules in HTML


### PR DESCRIPTION
## Summary
- prune debug logging in banks and main scripts
- warn only when bank population dependencies are missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: TS2669 and other TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e3c2f2dc832b970403d240cce789