### PR TITLE
chore: remove score result card

### DIFF
--- a/src/components/practiceHistory.js
+++ b/src/components/practiceHistory.js
@@ -1,5 +1,4 @@
 // Practice History Component - JavaScript Version
-import { formatBankName } from '../utils/bankNames';
 import { EMPTY_HISTORY } from '../utils/history';
 
 class PracticeHistoryComponent {
@@ -39,7 +38,7 @@ class PracticeHistoryComponent {
           <h2>📊 Practice Test History</h2>
           <button class="btn btn-secondary btn-sm" id="clearHistory">Clear History</button>
         </div>
-        
+
         <div class="history-stats">
           <div class="stat-card">
             <div class="stat-number">${this.history.totalTests}</div>
@@ -57,74 +56,6 @@ class PracticeHistoryComponent {
             <div class="stat-number">${Math.round(this.history.totalTime)}m</div>
             <div class="stat-label">Total Time</div>
           </div>
-        </div>
-
-        <div class="recent-results">
-          <h3>Recent Results</h3>
-          <div class="results-list">
-            ${this.history.results.slice(0, 5).map(result => this.generateResultCard(result)).join('')}
-          </div>
-        </div>
-
-        ${this.history.results.length > 5 ? `
-          <div class="view-all-results">
-            <button class="btn btn-secondary" id="viewAllResults">
-              View All ${this.history.results.length} Results
-            </button>
-          </div>
-        ` : ''}
-      </div>
-    `;
-  }
-
-  generateResultCard(result) {
-    const scoreClass = result.score >= 80 ? 'score-excellent' : 
-                      result.score >= 60 ? 'score-good' : 
-                      result.score >= 40 ? 'score-average' : 'score-poor';
-    
-    const date = new Date(result.date).toLocaleDateString('en-GB', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric'
-    });
-
-    const time = new Date(result.date).toLocaleTimeString('en-GB', {
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-
-    return `
-      <div class="result-card" data-result-id="${result.id}">
-        <div class="result-header">
-          <div class="result-bank">${formatBankName(result.bank)}</div>
-          <div class="result-date">${date} at ${time}</div>
-        </div>
-        <div class="result-details">
-          <div class="result-score ${scoreClass}">
-            <span class="score-number">${result.score}%</span>
-            <span class="score-label">Score</span>
-          </div>
-          <div class="result-stats">
-            <div class="stat">
-              <span class="stat-value">${result.correctAnswers}/${result.totalQuestions}</span>
-              <span class="stat-label">Correct</span>
-            </div>
-            <div class="stat">
-              <span class="stat-value">${result.duration}m</span>
-              <span class="stat-label">Time</span>
-            </div>
-            ${result.flaggedQuestions > 0 ? `
-              <div class="stat">
-                <span class="stat-value">${result.flaggedQuestions}</span>
-                <span class="stat-label">Flagged</span>
-              </div>
-            ` : ''}
-          </div>
-        </div>
-        <div class="result-actions">
-          <button class="btn btn-sm btn-primary review-result" data-result-id="${result.id}">
-            Review Test
-          </button>
         </div>
       </div>
     `;
@@ -157,104 +88,6 @@ class PracticeHistoryComponent {
       });
     }
 
-    // View all results button
-    const viewAllBtn = this.container.querySelector('#viewAllResults');
-    if (viewAllBtn) {
-      viewAllBtn.addEventListener('click', () => {
-        this.showAllResultsModal();
-      });
-    }
-
-    // Review result buttons
-    const reviewBtns = this.container.querySelectorAll('.review-result');
-    reviewBtns.forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        const resultId = e.target.getAttribute('data-result-id');
-        if (resultId) {
-          this.showResultDetails(resultId);
-        }
-      });
-    });
-  }
-
-  attachBackToSummary() {
-    if (!this.container) { return; }
-
-    const backBtn = this.container.querySelector('#backToSummary');
-    if (backBtn) {
-      backBtn.addEventListener('click', () => {
-        this.render(this.container.id);
-      });
-    }
-  }
-
-  showAllResultsModal() {
-    // Simplified: just show all results in the main area
-    if (this.container) {
-      this.container.innerHTML = `
-        <div class="practice-history">
-          <div class="history-header">
-            <h2>📊 All Practice Test Results</h2>
-            <button class="btn btn-secondary btn-sm" id="backToSummary">Back to Summary</button>
-          </div>
-          <div class="all-results-list">
-            ${this.history.results.map(result => this.generateResultCard(result)).join('')}
-          </div>
-        </div>
-      `;
-
-      this.attachBackToSummary();
-    }
-  }
-
-  showResultDetails(resultId) {
-    const result = this.history.results.find(r => r.id === resultId);
-    if (!result) {return;}
-
-    // Simplified: show basic result info in the main area
-    if (this.container) {
-      this.container.innerHTML = `
-        <div class="practice-history">
-          <div class="history-header">
-            <h2>📊 Test Result Details</h2>
-            <button class="btn btn-secondary btn-sm" id="backToSummary">Back to Summary</button>
-          </div>
-          <div class="result-summary">
-            <div class="summary-stats">
-              <div class="summary-stat">
-                <span class="stat-label">Bank:</span>
-                <span class="stat-value">${formatBankName(result.bank)}</span>
-              </div>
-              <div class="summary-stat">
-                <span class="stat-label">Score:</span>
-                <span class="stat-value">${result.score}%</span>
-              </div>
-              <div class="summary-stat">
-                <span class="stat-label">Questions:</span>
-                <span class="stat-value">${result.totalQuestions}</span>
-              </div>
-              <div class="summary-stat">
-                <span class="stat-label">Correct:</span>
-                <span class="stat-value">${result.correctAnswers}</span>
-              </div>
-              <div class="summary-stat">
-                <span class="stat-label">Duration:</span>
-                <span class="stat-value">${result.duration} minutes</span>
-              </div>
-              <div class="summary-stat">
-                <span class="stat-label">Date:</span>
-                <span class="stat-value">${new Date(result.date).toLocaleString()}</span>
-              </div>
-            </div>
-          </div>
-          <div class="button-row">
-            <button class="btn btn-primary" id="backToSummary">Back to Summary</button>
-          </div>
-        </div>
-      `;
-
-      this.attachBackToSummary();
-    }
   }
 
   // Storage methods

--- a/src/styles/consolidated.css
+++ b/src/styles/consolidated.css
@@ -1179,116 +1179,6 @@ body {
   font-weight: var(--font-weight-medium);
 }
 
-.recent-results h3 {
-  margin-bottom: var(--space-4);
-  color: var(--color-gray-900);
-  font-size: var(--font-size-xl);
-}
-
-.results-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-}
-
-.result-card {
-  background-color: var(--color-gray-50);
-  border: 1px solid var(--color-gray-200);
-  border-radius: var(--radius-lg);
-  padding: var(--space-4);
-  transition: all var(--transition-normal);
-}
-
-.result-card:hover {
-  box-shadow: var(--shadow-md);
-  transform: translateY(-1px);
-}
-
-.result-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: var(--space-3);
-}
-
-.result-bank {
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-gray-900);
-}
-
-.result-date {
-  font-size: var(--font-size-sm);
-  color: var(--color-gray-600);
-}
-
-.result-details {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-  margin-bottom: var(--space-3);
-}
-
-.result-score {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-md);
-  min-width: 80px;
-}
-
-.score-excellent {
-  background-color: rgb(16 185 129 / 0.1);
-  color: #065f46;
-}
-
-.score-good {
-  background-color: rgb(59 130 246 / 0.1);
-  color: #1e40af;
-}
-
-.score-average {
-  background-color: rgb(245 158 11 / 0.1);
-  color: #92400e;
-}
-
-.score-poor {
-  background-color: rgb(239 68 68 / 0.1);
-  color: #991b1b;
-}
-
-.score-number {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-bold);
-}
-
-.score-label {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-medium);
-}
-
-.result-stats {
-  display: flex;
-  gap: var(--space-4);
-  flex: 1;
-}
-
-.stat {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.stat-value {
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-gray-900);
-}
-
-.result-actions {
-  display: flex;
-  justify-content: flex-end;
-}
-
 .practice-history-empty {
   text-align: center;
   padding: var(--space-12);
@@ -1312,11 +1202,6 @@ body {
 .empty-state p {
   color: var(--color-gray-600);
   margin-bottom: var(--space-6);
-}
-
-.view-all-results {
-  text-align: center;
-  margin-top: var(--space-6);
 }
 
 /* ===== RESPONSIVE STYLES ===== */


### PR DESCRIPTION
## Summary
- remove score-based result cards and related logic
- drop unused score and result styles

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9e3d1e774832bbf609907a1f536eb