### PR TITLE
feat: delegate review result button clicks

### DIFF
--- a/src/components/practiceHistory.js
+++ b/src/components/practiceHistory.js
@@ -6,6 +6,15 @@ class PracticeHistoryComponent {
   constructor() {
     this.container = null;
     this.history = this.getPracticeHistory();
+    this.handleReviewClick = (e) => {
+      const reviewBtn = e.target.closest('.review-result');
+      if (reviewBtn) {
+        const resultId = reviewBtn.getAttribute('data-result-id');
+        if (resultId) {
+          this.showResultDetails(resultId);
+        }
+      }
+    };
   }
 
   render(containerId) {
@@ -165,16 +174,8 @@ class PracticeHistoryComponent {
       });
     }
 
-    // Review result buttons
-    const reviewBtns = this.container.querySelectorAll('.review-result');
-    reviewBtns.forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        const resultId = e.target.getAttribute('data-result-id');
-        if (resultId) {
-          this.showResultDetails(resultId);
-        }
-      });
-    });
+    // Delegate review button clicks to the container
+    this.container.addEventListener('click', this.handleReviewClick);
   }
 
   attachBackToSummary() {


### PR DESCRIPTION
## Summary
- delegate review button handling to a single container click listener
- add reusable click handler to detect `.review-result` and show details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: TS2669, TS7006, TS6133, TS2307, TS2304)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e3e12df8832bafd621bf1bbc6c82