### PR TITLE
refactor: convert practice history component to TS module

### DIFF
--- a/src/components/practiceHistory.ts
+++ b/src/components/practiceHistory.ts
@@ -1,14 +1,17 @@
-// Practice History Component - JavaScript Version
 import { EMPTY_HISTORY } from '../utils/history';
+import type { PracticeHistory, PracticeResult } from '@/types/question';
 
-class PracticeHistoryComponent {
+export class PracticeHistoryComponent {
+  private container: HTMLDivElement | null;
+  private history: PracticeHistory;
+
   constructor() {
     this.container = null;
     this.history = this.getPracticeHistory();
   }
 
-  render(containerId) {
-    this.container = document.getElementById(containerId);
+  render(containerId: string): void {
+    this.container = document.getElementById(containerId) as HTMLDivElement | null;
     if (!this.container) {
       console.warn('Practice history container not found:', containerId);
       return;
@@ -18,7 +21,7 @@ class PracticeHistoryComponent {
     this.attachEventListeners();
   }
 
-  generateHTML() {
+  private generateHTML(): string {
     if (this.history.totalTests === 0) {
       return `
         <div class="practice-history-empty">
@@ -61,37 +64,38 @@ class PracticeHistoryComponent {
     `;
   }
 
-  attachEventListeners() {
-    if (!this.container) {return;}
+  private attachEventListeners(): void {
+    if (!this.container) {
+      return;
+    }
 
     // Clear history button
-    const clearBtn = this.container.querySelector('#clearHistory');
+    const clearBtn = this.container.querySelector<HTMLButtonElement>('#clearHistory');
     if (clearBtn) {
       clearBtn.addEventListener('click', () => {
         if (confirm('Are you sure you want to clear all practice history? This cannot be undone.')) {
           this.clearPracticeHistory();
           this.history = this.getPracticeHistory();
-          this.render(this.container.id);
+          this.render(this.container!.id);
         }
       });
     }
 
     // Start first test button
-    const startFirstBtn = this.container.querySelector('#startFirstTest');
+    const startFirstBtn = this.container.querySelector<HTMLButtonElement>('#startFirstTest');
     if (startFirstBtn) {
       startFirstBtn.addEventListener('click', () => {
         // Focus on the practice section
-        const practiceBtn = document.getElementById('practiceBtn');
+        const practiceBtn = document.getElementById('practiceBtn') as HTMLButtonElement | null;
         if (practiceBtn) {
           practiceBtn.scrollIntoView({ behavior: 'smooth' });
         }
       });
     }
-
   }
 
   // Storage methods
-  getPracticeHistory() {
+  private getPracticeHistory(): PracticeHistory {
     try {
       const history = localStorage.getItem('practice_history');
       if (!history) {
@@ -106,7 +110,7 @@ class PracticeHistoryComponent {
     }
   }
 
-  calculateHistoryStats(results) {
+  private calculateHistoryStats(results: PracticeResult[]): PracticeHistory {
     const totalTests = results.length;
     const totalScore = results.reduce((sum, result) => sum + result.score, 0);
     const averageScore = totalTests > 0 ? Math.round((totalScore / totalTests) * 100) / 100 : 0;
@@ -118,11 +122,11 @@ class PracticeHistoryComponent {
       totalTests,
       averageScore,
       bestScore,
-      totalTime
+      totalTime,
     };
   }
 
-  clearPracticeHistory() {
+  private clearPracticeHistory(): void {
     try {
       localStorage.removeItem('practice_history');
       this.history = { ...EMPTY_HISTORY };
@@ -131,7 +135,7 @@ class PracticeHistoryComponent {
     }
   }
 
-  refresh() {
+  refresh(): void {
     this.history = this.getPracticeHistory();
     if (this.container) {
       this.render(this.container.id);
@@ -139,5 +143,5 @@ class PracticeHistoryComponent {
   }
 }
 
-// Make it available globally
-window.practiceHistoryComponent = new PracticeHistoryComponent();
+const practiceHistoryComponent = new PracticeHistoryComponent();
+export default practiceHistoryComponent;

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -49,13 +49,12 @@ declare global {
     
     // Application state
     banks?: QuestionBank;
-    populateBankSelects?: (banks: QuestionBank) => void;
-    questionRenderer?: QuestionRenderer;
-    toggleFlag?: (id: number) => boolean;
-    practiceHistoryComponent?: any;
-    // Timer functionality removed
+      populateBankSelects?: (banks: QuestionBank) => void;
+      questionRenderer?: QuestionRenderer;
+      toggleFlag?: (id: number) => boolean;
+      // Timer functionality removed
+    }
   }
-}
 
 export interface QuestionStats {
   [questionId: number]: {

--- a/templates/index.html
+++ b/templates/index.html
@@ -174,14 +174,9 @@
   <script type="module" src="/static/banks.ts"></script>
   <script type="module" src="/static/question_renderer.ts"></script>
   <script type="module" src="/static/main.ts"></script>
-  <script src="/src/components/practiceHistory.js"></script>
-  <script>
-    // Initialize practice history component
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.practiceHistoryComponent) {
-        window.practiceHistoryComponent.render('practiceHistory');
-      }
-    });
+  <script type="module">
+    import practiceHistoryComponent from '/src/components/practiceHistory.ts';
+    practiceHistoryComponent.render('practiceHistory');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- convert practice history component to TypeScript module with typed DOM lookups
- remove global window attachment and import component as ES module
- update index template to load the compiled module

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check` *(fails: Augmentations for the global scope..., Cannot find module 'path', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a9eb150184832b9c28f474bb36f35b