### PR TITLE
refactor: use ES modules and remove globals

### DIFF
--- a/src/components/practiceHistory.js
+++ b/src/components/practiceHistory.js
@@ -1,7 +1,7 @@
 // Practice History Component - JavaScript Version
 import { EMPTY_HISTORY } from '../utils/history';
 
-class PracticeHistoryComponent {
+export class PracticeHistoryComponent {
   constructor() {
     this.container = null;
     this.history = this.getPracticeHistory();
@@ -139,5 +139,3 @@ class PracticeHistoryComponent {
   }
 }
 
-// Make it available globally
-window.practiceHistoryComponent = new PracticeHistoryComponent();

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -33,30 +33,6 @@ export interface BankLabels {
   [key: string]: string;
 }
 
-// Global window interface extensions
-declare global {
-  interface Window {
-    // Question bank data (loaded by question bank JS files)
-    calculations?: Question[];
-    clinicalMepLow?: Question[];
-    clinicalMixedHigh?: Question[];
-    clinicalMixedLow?: Question[];
-    clinicalMixedMedium?: Question[];
-    clinicalOtcLow?: Question[];
-    clinicalTherapeuticsHigh?: Question[];
-    clinicalTherapeuticsLow?: Question[];
-    clinicalTherapeuticsMedium?: Question[];
-    
-    // Application state
-    banks?: QuestionBank;
-    populateBankSelects?: (banks: QuestionBank) => void;
-    questionRenderer?: QuestionRenderer;
-    toggleFlag?: (id: number) => boolean;
-    practiceHistoryComponent?: any;
-    // Timer functionality removed
-  }
-}
-
 export interface QuestionStats {
   [questionId: number]: {
     attempts: number;

--- a/static/banks.ts
+++ b/static/banks.ts
@@ -1,51 +1,19 @@
-// Type definitions moved inline to avoid import issues
-interface QuestionBank {
-  [key: string]: any[][];
-}
+import type { QuestionBank } from '@/types/question';
 
-// Extend window interface
-declare global {
-  interface Window {
-    populateBankSelects?: (banks: QuestionBank) => void;
-  }
-}
-
-function initializeBanks(): void {
-  const banks: QuestionBank = {
-    calculations: [window.calculations || []],
-    clinical_mep: [window.clinicalMepLow || []],
+export function loadBanks(): QuestionBank {
+  return {
+    calculations: [(window as any).calculations || []],
+    clinical_mep: [(window as any).clinicalMepLow || []],
     clinical_mixed: [
-      window.clinicalMixedHigh || [],
-      window.clinicalMixedLow || [],
-      window.clinicalMixedMedium || [],
+      (window as any).clinicalMixedHigh || [],
+      (window as any).clinicalMixedLow || [],
+      (window as any).clinicalMixedMedium || [],
     ],
-    clinical_otc: [window.clinicalOtcLow || []],
+    clinical_otc: [(window as any).clinicalOtcLow || []],
     clinical_therapeutics: [
-      window.clinicalTherapeuticsHigh || [],
-      window.clinicalTherapeuticsLow || [],
-      window.clinicalTherapeuticsMedium || [],
+      (window as any).clinicalTherapeuticsHigh || [],
+      (window as any).clinicalTherapeuticsLow || [],
+      (window as any).clinicalTherapeuticsMedium || [],
     ],
   };
-  window.banks = banks;
-
-  // Try to populate banks immediately if function is available
-  if (window.populateBankSelects) {
-    window.populateBankSelects(banks);
-  } else {
-    // Retry after a short delay to allow main.ts to load
-    setTimeout(() => {
-      if (window.populateBankSelects) {
-        window.populateBankSelects(banks);
-      } else {
-        console.warn('populateBankSelects not available');
-      }
-    }, 100);
-  }
-}
-
-// Initialize when DOM is ready
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initializeBanks);
-} else {
-  initializeBanks();
 }

--- a/static/main.ts
+++ b/static/main.ts
@@ -1,52 +1,19 @@
-import type { Question, QuestionBank, BankData } from '@/types/question';
+import type { Question, QuestionBank, BankData, QuestionRenderer } from '@/types/question';
 import { formatBankName } from '@/utils/bankNames';
 import { evaluateAnswer, getCorrectAnswerText } from '@/utils/answers';
 
-let bankFiles: QuestionBank = (window as any).banks || {};
-const flagged = new Set<number>();
+let bankFiles: QuestionBank = {};
+let renderer: QuestionRenderer;
 let banksPopulated = false;
-
-const loadBtn = document.getElementById('loadBtn') as HTMLButtonElement | null;
-if (loadBtn) {
-  loadBtn.addEventListener('click', loadQuestion);
-}
-
-const practiceBtn = document.getElementById(
-  'practiceBtn'
-) as HTMLButtonElement | null;
-if (practiceBtn) {
-  practiceBtn.addEventListener('click', startPractice);
-}
-
-// Add event handlers for question buttons
 let currentQuestion: Question | null = null;
 
-const checkBtn = document.getElementById(
-  'checkBtn'
-) as HTMLButtonElement | null;
-if (checkBtn) {
-  checkBtn.addEventListener('click', checkAnswer);
-}
-
-const revealBtn = document.getElementById(
-  'revealBtn'
-) as HTMLButtonElement | null;
-if (revealBtn) {
-  revealBtn.addEventListener('click', revealAnswer);
-}
-
 function populateBankSelects(data: QuestionBank): void {
-  // Prevent duplicate population
   if (banksPopulated) {
     return;
   }
 
-  const bankSelect = document.getElementById(
-    'bankSelect'
-  ) as HTMLSelectElement | null;
-  const statsSelect = document.getElementById(
-    'statsBankSelect'
-  ) as HTMLSelectElement | null;
+  const bankSelect = document.getElementById('bankSelect') as HTMLSelectElement | null;
+  const statsSelect = document.getElementById('statsBankSelect') as HTMLSelectElement | null;
 
   if (!bankSelect && !statsSelect) {
     console.warn('Bank select elements not found');
@@ -72,7 +39,6 @@ function populateBankSelects(data: QuestionBank): void {
     }
   });
 
-  // Mark as populated to prevent duplicates
   banksPopulated = true;
 }
 
@@ -95,65 +61,6 @@ function getSelectedBank(id: string): BankData | null {
   return { bank, files };
 }
 
-function toggleFlag(id: number): boolean {
-  if (flagged.has(id)) {
-    flagged.delete(id);
-    return false;
-  }
-  flagged.add(id);
-  return true;
-}
-
-(window as any).toggleFlag = toggleFlag;
-
-// Make populateBankSelects available globally
-(window as any).populateBankSelects = populateBankSelects;
-
-// Adjust layout when loaded in standalone mode
-document.addEventListener('DOMContentLoaded', function () {
-  // Ensure statsModal is hidden by default
-  const statsModal = document.getElementById('statsModal');
-  if (statsModal) {
-    statsModal.classList.remove('show');
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  if (params.get('isStandAlone') === 'true') {
-    document.body.classList.add('standalone');
-    const container = document.querySelector('.container');
-    if (container) {
-      container.classList.add('standalone');
-    }
-  }
-
-  // Update bankFiles if banks have been loaded
-  if ((window as any).banks) {
-    bankFiles = (window as any).banks;
-    populateBankSelects(bankFiles);
-  } else {
-    console.warn('No banks found in window yet');
-  }
-
-  // Preselect the last used bank if available
-  try {
-    const last = localStorage.getItem('lastBank');
-    if (last) {
-      const bankSelect = document.getElementById(
-        'bankSelect'
-      ) as HTMLSelectElement | null;
-      if (bankSelect && bankFiles[last]) {
-        bankSelect.value = last;
-      }
-    }
-  } catch (e) {
-    console.warn('Failed to load lastBank', e);
-  }
-
-  if ((window as any).questionRenderer) {
-    (window as any).questionRenderer.initPdfViewer();
-  }
-});
-
 function loadQuestion(): void {
   const data = getSelectedBank('bankSelect');
   if (!data) {
@@ -167,14 +74,10 @@ function loadQuestion(): void {
 }
 
 function renderQuestion(question: Question): void {
-  // Store current question for button actions
   currentQuestion = question;
 
-  // Store the selected bank for next time
   try {
-    const bankSelect = document.getElementById(
-      'bankSelect'
-    ) as HTMLSelectElement | null;
+    const bankSelect = document.getElementById('bankSelect') as HTMLSelectElement | null;
     if (bankSelect && bankSelect.value) {
       localStorage.setItem('lastBank', bankSelect.value);
     }
@@ -182,28 +85,23 @@ function renderQuestion(question: Question): void {
     console.warn('Failed to save lastBank', e);
   }
 
-  // Render the question using the question renderer
-  if ((window as any).questionRenderer) {
-    (window as any).questionRenderer.renderQuestion(question, {
-      text: '#qText',
-      title: '#qTitle',
-      img: '#qImg',
-      options: '#answerOptions',
-      input: '.calculator',
-      unit: '#answerUnit',
-      feedback: '#feedback',
-      answer: '#answer',
-      explanation: '#explanation',
-    });
-  }
+  renderer.renderQuestion(question, {
+    text: '#qText',
+    title: '#qTitle',
+    img: '#qImg',
+    options: '#answerOptions',
+    input: '.calculator',
+    unit: '#answerUnit',
+    feedback: '#feedback',
+    answer: '#answer',
+    explanation: '#explanation',
+  });
 
-  // Show the question area
   const questionArea = document.getElementById('questionArea');
   if (questionArea) {
     questionArea.style.display = 'block';
   }
 
-  // Reset feedback
   const feedbackEl = document.getElementById('feedback');
   if (feedbackEl) {
     feedbackEl.textContent = '';
@@ -218,35 +116,30 @@ function startPractice(): void {
     return;
   }
 
-  // Get number of questions
   const numInput = document.getElementById('numInput') as HTMLInputElement;
   const numQuestions = numInput ? parseInt(numInput.value) || 10 : 10;
 
-  // Check for existing session
   const sessionKey = `practice_session_${data.bank}_${numQuestions}`;
   const existingSession = sessionStorage.getItem(sessionKey);
 
   if (existingSession) {
-    const confirmResume = confirm(
+    const confirmResume = window.confirm(
       'You have an unfinished practice session for this bank. Would you like to resume where you left off?'
     );
     if (confirmResume) {
       window.location.href = `practice.html?bank=${encodeURIComponent(data.bank)}&num=${numQuestions}&resume=true`;
       return;
     } else {
-      // User wants to start fresh, clear the old session
       sessionStorage.removeItem(sessionKey);
     }
   }
 
-  // Store the selected bank for next time
   try {
     localStorage.setItem('lastBank', data.bank);
   } catch (e) {
     console.warn('Failed to save lastBank', e);
   }
 
-  // Redirect to practice page with bank and number parameters
   window.location.href = `practice.html?bank=${encodeURIComponent(data.bank)}&num=${numQuestions}`;
 }
 
@@ -255,7 +148,6 @@ function checkAnswer(): void {
     return;
   }
 
-  // Get user answer first
   let userAnswer = '';
 
   if (currentQuestion.is_calculation) {
@@ -266,9 +158,7 @@ function checkAnswer(): void {
     }
     userAnswer = calcInput.value;
   } else {
-    const selectedOption = document.querySelector(
-      'input[name="answer"]:checked'
-    ) as HTMLInputElement;
+    const selectedOption = document.querySelector('input[name="answer"]:checked') as HTMLInputElement;
     if (!selectedOption) {
       alert('Please select an answer first');
       return;
@@ -280,19 +170,14 @@ function checkAnswer(): void {
   revealAnswerWithFeedback(currentQuestion, isCorrect);
 }
 
-function revealAnswerWithFeedback(
-  question: Question,
-  isCorrect: boolean
-): void {
+function revealAnswerWithFeedback(question: Question, isCorrect: boolean): void {
   const feedbackEl = document.getElementById('feedback');
   const answerEl = document.getElementById('answer');
   const explanationEl = document.getElementById('explanation');
 
   if (feedbackEl) {
     feedbackEl.textContent = isCorrect ? 'Correct!' : 'Incorrect';
-    feedbackEl.className = isCorrect
-      ? 'feedback correct'
-      : 'feedback incorrect';
+    feedbackEl.className = isCorrect ? 'feedback correct' : 'feedback incorrect';
   }
 
   if (answerEl) {
@@ -314,10 +199,8 @@ function revealAnswer(): void {
     return;
   }
 
-  // Use the same rendering logic but without feedback
   revealAnswerWithFeedback(currentQuestion, false);
 
-  // Clear any existing feedback since this is just revealing the answer
   const feedbackEl = document.getElementById('feedback');
   if (feedbackEl) {
     feedbackEl.textContent = '';
@@ -325,5 +208,57 @@ function revealAnswer(): void {
   }
 }
 
-// Functions are available globally via window object
-// No need to export since we're not using ES modules in HTML
+export function initMain(banks: QuestionBank, questionRendererInst: QuestionRenderer): void {
+  bankFiles = banks;
+  renderer = questionRendererInst;
+
+  populateBankSelects(bankFiles);
+
+  const loadBtn = document.getElementById('loadBtn') as HTMLButtonElement | null;
+  if (loadBtn) {
+    loadBtn.addEventListener('click', loadQuestion);
+  }
+
+  const practiceBtn = document.getElementById('practiceBtn') as HTMLButtonElement | null;
+  if (practiceBtn) {
+    practiceBtn.addEventListener('click', startPractice);
+  }
+
+  const checkBtn = document.getElementById('checkBtn') as HTMLButtonElement | null;
+  if (checkBtn) {
+    checkBtn.addEventListener('click', checkAnswer);
+  }
+
+  const revealBtn = document.getElementById('revealBtn') as HTMLButtonElement | null;
+  if (revealBtn) {
+    revealBtn.addEventListener('click', revealAnswer);
+  }
+
+  const statsModal = document.getElementById('statsModal');
+  if (statsModal) {
+    statsModal.classList.remove('show');
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('isStandAlone') === 'true') {
+    document.body.classList.add('standalone');
+    const container = document.querySelector('.container');
+    if (container) {
+      container.classList.add('standalone');
+    }
+  }
+
+  try {
+    const last = localStorage.getItem('lastBank');
+    if (last) {
+      const bankSelect = document.getElementById('bankSelect') as HTMLSelectElement | null;
+      if (bankSelect && bankFiles[last]) {
+        bankSelect.value = last;
+      }
+    }
+  } catch (e) {
+    console.warn('Failed to load lastBank', e);
+  }
+
+  renderer.initPdfViewer();
+}

--- a/static/question_renderer.ts
+++ b/static/question_renderer.ts
@@ -187,10 +187,7 @@ function initPdfViewer(): void {
 }
 
 // Create the question renderer object
-const questionRenderer: QuestionRenderer = {
+export const questionRenderer: QuestionRenderer = {
   initPdfViewer,
   renderQuestion
 };
-
-// Make it available globally
-(window as any).questionRenderer = questionRenderer;

--- a/static/summary.ts
+++ b/static/summary.ts
@@ -1,15 +1,15 @@
 // Summary Page Logic - Dedicated Implementation
 
-import type { PracticeResult } from '@/types/question';
+import type { PracticeResult, QuestionRenderer } from '@/types/question';
 import { EMPTY_HISTORY } from '@/utils/history';
 import { evaluateAnswer, getCorrectAnswerText } from '@/utils/answers';
 
-class SummaryManager {
+export class SummaryManager {
   private testResult: PracticeResult | null = null;
   private currentReviewQuestion: number = 0;
   private reviewMode: 'all' | 'incorrect' | 'flagged' = 'all';
 
-  constructor() {
+  constructor(private renderer: QuestionRenderer) {
     this.init();
   }
 
@@ -210,9 +210,9 @@ class SummaryManager {
       modalTitle.textContent = `Question ${questionNum + 1} Review`;
     }
 
-    // Render question using global renderer
-    if ((window as any).questionRenderer) {
-      (window as any).questionRenderer.renderQuestion(question, {
+    // Render question using provided renderer
+    if (this.renderer) {
+      this.renderer.renderQuestion(question, {
         text: '#reviewQuestionText',
         title: '#reviewQuestionTitle',
         img: '#reviewQuestionImage',
@@ -305,11 +305,4 @@ class SummaryManager {
   }
 }
 
-// Initialize summary manager when DOM is ready
-document.addEventListener('DOMContentLoaded', function() {
-  console.log('Summary page initializing...');
-  new SummaryManager();
-});
-
-// Make class available globally if needed
-(window as any).SummaryManager = SummaryManager;
+// Class is exported for module-based initialization

--- a/templates/index.html
+++ b/templates/index.html
@@ -171,17 +171,17 @@
   <script src="/question_banks/clinical_therapeutics_high_questions.js"></script>
   <script src="/question_banks/clinical_therapeutics_low_questions.js"></script>
   <script src="/question_banks/clinical_therapeutics_medium_questions.js"></script>
-  <script type="module" src="/static/banks.ts"></script>
-  <script type="module" src="/static/question_renderer.ts"></script>
-  <script type="module" src="/static/main.ts"></script>
-  <script src="/src/components/practiceHistory.js"></script>
-  <script>
-    // Initialize practice history component
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.practiceHistoryComponent) {
-        window.practiceHistoryComponent.render('practiceHistory');
-      }
-    });
+  <script type="module">
+    import { loadBanks } from '/static/banks.ts';
+    import { questionRenderer } from '/static/question_renderer.ts';
+    import { initMain } from '/static/main.ts';
+    import { PracticeHistoryComponent } from '/src/components/practiceHistory.js';
+
+    const banks = loadBanks();
+    initMain(banks, questionRenderer);
+
+    const practiceHistory = new PracticeHistoryComponent();
+    practiceHistory.render('practiceHistory');
   </script>
 </body>
 </html>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -125,8 +125,14 @@
   <script src="../question_banks/clinical_therapeutics_high_questions.js"></script>
   <script src="../question_banks/clinical_therapeutics_low_questions.js"></script>
   <script src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
-  <script type="module" src="/static/banks.ts"></script>
-  <script type="module" src="/static/question_renderer.ts"></script>
-  <script type="module" src="/static/practice.ts"></script>
+  <script type="module">
+    import { loadBanks } from '/static/banks.ts';
+    import { questionRenderer } from '/static/question_renderer.ts';
+    import { PracticeManager } from '/static/practice.ts';
+
+    const banks = loadBanks();
+    const practiceManager = new PracticeManager(banks, questionRenderer);
+    practiceManager.init();
+  </script>
 </body>
 </html>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -113,8 +113,11 @@
   <script src="../question_banks/clinical_therapeutics_high_questions.js"></script>
   <script src="../question_banks/clinical_therapeutics_low_questions.js"></script>
   <script src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
-  <script type="module" src="/static/banks.ts"></script>
-  <script type="module" src="/static/question_renderer.ts"></script>
-  <script type="module" src="/static/summary.ts"></script>
+  <script type="module">
+    import { questionRenderer } from '/static/question_renderer.ts';
+    import { SummaryManager } from '/static/summary.ts';
+
+    new SummaryManager(questionRenderer);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- export PracticeHistoryComponent, PracticeManager and SummaryManager directly from their modules
- import application modules via `type="module"` scripts in templates and initialize without globals
- remove obsolete global `Window` extensions and use explicit cross-module imports

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module 'path')*

------
https://chatgpt.com/codex/tasks/task_e_68a9eb3fa048832ba65f8479f09d61f5