### PR TITLE
refactor: use module exports and explicit imports

### DIFF
--- a/src/components/practiceHistory.ts
+++ b/src/components/practiceHistory.ts
@@ -142,6 +142,3 @@ export class PracticeHistoryComponent {
     }
   }
 }
-
-const practiceHistoryComponent = new PracticeHistoryComponent();
-export default practiceHistoryComponent;

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -33,29 +33,6 @@ export interface BankLabels {
   [key: string]: string;
 }
 
-// Global window interface extensions
-declare global {
-  interface Window {
-    // Question bank data (loaded by question bank JS files)
-    calculations?: Question[];
-    clinicalMepLow?: Question[];
-    clinicalMixedHigh?: Question[];
-    clinicalMixedLow?: Question[];
-    clinicalMixedMedium?: Question[];
-    clinicalOtcLow?: Question[];
-    clinicalTherapeuticsHigh?: Question[];
-    clinicalTherapeuticsLow?: Question[];
-    clinicalTherapeuticsMedium?: Question[];
-    
-    // Application state
-    banks?: QuestionBank;
-      populateBankSelects?: (banks: QuestionBank) => void;
-      questionRenderer?: QuestionRenderer;
-      toggleFlag?: (id: number) => boolean;
-      // Timer functionality removed
-    }
-  }
-
 export interface QuestionStats {
   [questionId: number]: {
     attempts: number;

--- a/static/banks.ts
+++ b/static/banks.ts
@@ -1,51 +1,21 @@
-// Type definitions moved inline to avoid import issues
 interface QuestionBank {
   [key: string]: any[][];
 }
 
-// Extend window interface
-declare global {
-  interface Window {
-    populateBankSelects?: (banks: QuestionBank) => void;
-  }
-}
+export const banks: QuestionBank = {
+  calculations: [ (window as any).calculations || [] ],
+  clinical_mep: [ (window as any).clinicalMepLow || [] ],
+  clinical_mixed: [
+    (window as any).clinicalMixedHigh || [],
+    (window as any).clinicalMixedLow || [],
+    (window as any).clinicalMixedMedium || [],
+  ],
+  clinical_otc: [ (window as any).clinicalOtcLow || [] ],
+  clinical_therapeutics: [
+    (window as any).clinicalTherapeuticsHigh || [],
+    (window as any).clinicalTherapeuticsLow || [],
+    (window as any).clinicalTherapeuticsMedium || [],
+  ],
+};
 
-function initializeBanks(): void {
-  const banks: QuestionBank = {
-    calculations: [window.calculations || []],
-    clinical_mep: [window.clinicalMepLow || []],
-    clinical_mixed: [
-      window.clinicalMixedHigh || [],
-      window.clinicalMixedLow || [],
-      window.clinicalMixedMedium || [],
-    ],
-    clinical_otc: [window.clinicalOtcLow || []],
-    clinical_therapeutics: [
-      window.clinicalTherapeuticsHigh || [],
-      window.clinicalTherapeuticsLow || [],
-      window.clinicalTherapeuticsMedium || [],
-    ],
-  };
-  window.banks = banks;
-
-  // Try to populate banks immediately if function is available
-  if (window.populateBankSelects) {
-    window.populateBankSelects(banks);
-  } else {
-    // Retry after a short delay to allow main.ts to load
-    setTimeout(() => {
-      if (window.populateBankSelects) {
-        window.populateBankSelects(banks);
-      } else {
-        console.warn('populateBankSelects not available');
-      }
-    }, 100);
-  }
-}
-
-// Initialize when DOM is ready
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initializeBanks);
-} else {
-  initializeBanks();
-}
+export default banks;

--- a/static/practice.ts
+++ b/static/practice.ts
@@ -8,10 +8,12 @@ import type {
 import { formatBankName } from '@/utils/bankNames';
 import { EMPTY_HISTORY } from '@/utils/history';
 import { evaluateAnswer, getCorrectAnswerText } from '@/utils/answers';
+import { banks } from './banks';
+import { questionRenderer } from './question_renderer';
 
 // Timer functionality removed - practice mode runs without time constraints
 
-class PracticeManager {
+export class PracticeManager {
   private state: PracticeState | null = null;
   private isFinished: boolean = false;
   private sessionKey: string = '';
@@ -26,7 +28,7 @@ class PracticeManager {
     const numQuestions = parseInt(params.get('num') || '10');
     const resume = params.get('resume') === 'true';
 
-    if (!bank || !(window as any).banks || !(window as any).banks[bank]) {
+    if (!bank || !banks || !banks[bank]) {
       alert('No valid question bank selected');
       window.location.href = 'index.html';
     return;
@@ -51,7 +53,7 @@ class PracticeManager {
   }
 
   private setupPracticeSession(bank: string, numQuestions: number): void {
-    const bankData = (window as any).banks![bank];
+    const bankData = banks[bank];
     if (!bankData || !bankData.length) {
       alert('Question bank is empty');
     return;
@@ -173,8 +175,8 @@ class PracticeManager {
     }
 
     // Render question using global renderer
-    if ((window as any).questionRenderer) {
-      (window as any).questionRenderer.renderQuestion(question, {
+    if (questionRenderer) {
+      questionRenderer.renderQuestion(question, {
         text: '#qText',
         title: '#qTitle',
         img: '#qImg',
@@ -555,7 +557,7 @@ class PracticeManager {
       }
       
       // Reconstruct questions from IDs
-      const bankData = (window as any).banks![data.bank];
+    const bankData = banks[data.bank];
       const allQuestions: Question[] = [];
       bankData.forEach((questionArray: Question[]) => {
         allQuestions.push(...questionArray);
@@ -605,13 +607,4 @@ class PracticeManager {
   }
 }
 
-// Initialize practice manager when DOM is ready
-document.addEventListener('DOMContentLoaded', function() {
-  console.log('Practice mode initializing...');
-  const practiceManager = new PracticeManager();
-  practiceManager.init();
-});
-
-// Make classes available globally if needed
-(window as any).PracticeManager = PracticeManager;
 // Timer class removed - no longer needed

--- a/static/question_renderer.ts
+++ b/static/question_renderer.ts
@@ -187,10 +187,9 @@ function initPdfViewer(): void {
 }
 
 // Create the question renderer object
-const questionRenderer: QuestionRenderer = {
+export const questionRenderer: QuestionRenderer = {
   initPdfViewer,
   renderQuestion
 };
 
-// Make it available globally
-(window as any).questionRenderer = questionRenderer;
+export default questionRenderer;

--- a/static/summary.ts
+++ b/static/summary.ts
@@ -3,8 +3,9 @@
 import type { PracticeResult } from '@/types/question';
 import { EMPTY_HISTORY } from '@/utils/history';
 import { evaluateAnswer, getCorrectAnswerText } from '@/utils/answers';
+import { questionRenderer } from './question_renderer';
 
-class SummaryManager {
+export class SummaryManager {
   private testResult: PracticeResult | null = null;
   private currentReviewQuestion: number = 0;
   private reviewMode: 'all' | 'incorrect' | 'flagged' = 'all';
@@ -210,9 +211,9 @@ class SummaryManager {
       modalTitle.textContent = `Question ${questionNum + 1} Review`;
     }
 
-    // Render question using global renderer
-    if ((window as any).questionRenderer) {
-      (window as any).questionRenderer.renderQuestion(question, {
+    // Render question using renderer
+    if (questionRenderer) {
+      questionRenderer.renderQuestion(question, {
         text: '#reviewQuestionText',
         title: '#reviewQuestionTitle',
         img: '#reviewQuestionImage',
@@ -305,11 +306,4 @@ class SummaryManager {
   }
 }
 
-// Initialize summary manager when DOM is ready
-document.addEventListener('DOMContentLoaded', function() {
-  console.log('Summary page initializing...');
-  new SummaryManager();
-});
-
-// Make class available globally if needed
-(window as any).SummaryManager = SummaryManager;
+// SummaryManager is exported and should be instantiated by the page script

--- a/templates/index.html
+++ b/templates/index.html
@@ -171,12 +171,12 @@
   <script src="/question_banks/clinical_therapeutics_high_questions.js"></script>
   <script src="/question_banks/clinical_therapeutics_low_questions.js"></script>
   <script src="/question_banks/clinical_therapeutics_medium_questions.js"></script>
-  <script type="module" src="/static/banks.ts"></script>
-  <script type="module" src="/static/question_renderer.ts"></script>
-  <script type="module" src="/static/main.ts"></script>
   <script type="module">
-    import practiceHistoryComponent from '/src/components/practiceHistory.ts';
-    practiceHistoryComponent.render('practiceHistory');
+    import { init } from '/static/main.ts';
+    import { PracticeHistoryComponent } from '/src/components/practiceHistory.ts';
+    init();
+    const practiceHistory = new PracticeHistoryComponent();
+    practiceHistory.render('practiceHistory');
   </script>
 </body>
 </html>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -125,8 +125,10 @@
   <script src="../question_banks/clinical_therapeutics_high_questions.js"></script>
   <script src="../question_banks/clinical_therapeutics_low_questions.js"></script>
   <script src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
-  <script type="module" src="/static/banks.ts"></script>
-  <script type="module" src="/static/question_renderer.ts"></script>
-  <script type="module" src="/static/practice.ts"></script>
+  <script type="module">
+    import { PracticeManager } from '/static/practice.ts';
+    const practiceManager = new PracticeManager();
+    practiceManager.init();
+  </script>
 </body>
 </html>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -113,8 +113,9 @@
   <script src="../question_banks/clinical_therapeutics_high_questions.js"></script>
   <script src="../question_banks/clinical_therapeutics_low_questions.js"></script>
   <script src="../question_banks/clinical_therapeutics_medium_questions.js"></script>
-  <script type="module" src="/static/banks.ts"></script>
-  <script type="module" src="/static/question_renderer.ts"></script>
-  <script type="module" src="/static/summary.ts"></script>
+  <script type="module">
+    import { SummaryManager } from '/static/summary.ts';
+    new SummaryManager();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- export modules instead of attaching to `window`
- load modules via `<script type="module">` in templates and init explicitly
- drop obsolete global interface extensions

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module 'path' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ed377348832ba09c558fc097c3ea