### PR TITLE
Refactor module exports and clean up global types

### DIFF
--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -74,21 +74,3 @@ export interface PracticeHistory {
   bestScore: number;
   totalTime: number; // in minutes
 }
-
-export interface RenderOptions {
-  text?: string;
-  title?: string;
-  img?: string;
-  options?: string;
-  input?: string;
-  unit?: string;
-  feedback?: string;
-  answer?: string;
-  explanation?: string;
-  showInput?: boolean;
-}
-
-export interface QuestionRenderer {
-  initPdfViewer(): void;
-  renderQuestion(question: Question, config?: RenderOptions): void;
-}

--- a/static/banks.ts
+++ b/static/banks.ts
@@ -17,5 +17,3 @@ export const banks: QuestionBank = {
     (window as any).clinicalTherapeuticsMedium || [],
   ],
 };
-
-export default banks;

--- a/static/question_renderer.ts
+++ b/static/question_renderer.ts
@@ -1,8 +1,22 @@
-import type {
-  Question,
-  RenderOptions,
-  QuestionRenderer,
-} from '@/types/question';
+import type { Question } from '@/types/question';
+
+interface RenderOptions {
+  text?: string;
+  title?: string;
+  img?: string;
+  options?: string;
+  input?: string;
+  unit?: string;
+  feedback?: string;
+  answer?: string;
+  explanation?: string;
+  showInput?: boolean;
+}
+
+interface QuestionRenderer {
+  initPdfViewer(): void;
+  renderQuestion(question: Question, config?: RenderOptions): void;
+}
 
 function sanitize(content: string, inline: boolean = false): string {
   if (typeof (window as any).DOMPurify !== 'undefined' && typeof (window as any).marked !== 'undefined') {
@@ -191,5 +205,3 @@ export const questionRenderer: QuestionRenderer = {
   initPdfViewer,
   renderQuestion
 };
-
-export default questionRenderer;


### PR DESCRIPTION
## Summary
- localize RenderOptions and QuestionRenderer types to question renderer module
- remove default exports from banks and question renderer modules to rely on named exports
- drop obsolete type declarations from src/types/question.ts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module 'path' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a9efa054b4832ba002f3de29e6db64