### PR TITLE
refactor: centralize question option styles

### DIFF
--- a/src/components/QuestionRenderer.tsx
+++ b/src/components/QuestionRenderer.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { Question } from '@/types/question';
+
+interface QuestionRendererProps {
+  question: Question;
+  variant: 'index' | 'practice';
+  onAnswerChange?: (value: string) => void;
+  selectedAnswer?: string;
+}
+
+function sanitize(content: string, inline = false): string {
+  if (typeof (window as any).DOMPurify !== 'undefined' && typeof (window as any).marked !== 'undefined') {
+    try {
+      const rawHtml = inline
+        ? (window as any).marked.parseInline(content)
+        : (window as any).marked.parse(content);
+      return (window as any).DOMPurify.sanitize(rawHtml);
+    } catch (e) {
+      console.warn('Error processing markdown:', e);
+      return content;
+    }
+  }
+  return content;
+}
+
+function enhanceLinksAndImages(element: HTMLElement): void {
+  const images = element.querySelectorAll('img[src^="resources/"]');
+  images.forEach(img => {
+    const imgEl = img as HTMLImageElement;
+    imgEl.style.cursor = 'pointer';
+    imgEl.onclick = () => window.open(imgEl.src, '_blank');
+  });
+
+  const links = element.querySelectorAll('a[href$=".pdf"]');
+  links.forEach(link => {
+    const linkEl = link as HTMLAnchorElement;
+    linkEl.target = '_blank';
+  });
+}
+
+const QuestionRenderer: React.FC<QuestionRendererProps> = ({
+  question,
+  variant,
+  onAnswerChange,
+  selectedAnswer
+}) => {
+  const [selected, setSelected] = useState<string>(selectedAnswer || '');
+  const textRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setSelected(selectedAnswer || '');
+  }, [selectedAnswer, question]);
+
+  useEffect(() => {
+    if (textRef.current) enhanceLinksAndImages(textRef.current);
+    if (titleRef.current) enhanceLinksAndImages(titleRef.current);
+  }, [question]);
+
+  const handleSelect = (value: string) => {
+    const newValue = selected === value ? '' : value;
+    setSelected(newValue);
+    onAnswerChange?.(newValue);
+  };
+
+  const renderOptions = () => {
+    if (!question.answers) return null;
+    return (
+      <div className={`question-options ${variant}`}>
+        {question.answers.map(answer => {
+          const value = String(answer.answer_number);
+          const isSelected = selected === value;
+          return (
+            <label
+              key={value}
+              className={isSelected ? 'selected' : undefined}
+              onClick={e => {
+                e.preventDefault();
+                handleSelect(value);
+              }}
+            >
+              <input
+                type="radio"
+                name="answer"
+                value={value}
+                checked={isSelected}
+                readOnly
+              />
+              <span>{answer.text}</span>
+            </label>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const rawTitle = question.title || '';
+  const needsBlock = /\n/.test(rawTitle) || /(^|\n)\s*\*\s/.test(rawTitle);
+  const titleHtml = sanitize(rawTitle, !needsBlock);
+  const textHtml = sanitize(question.text || '', false);
+
+  return (
+    <div className="question-renderer">
+      {question.title && (
+        <div
+          ref={titleRef}
+          className="question-title"
+          dangerouslySetInnerHTML={{ __html: titleHtml }}
+        />
+      )}
+      {question.text && (
+        <div
+          ref={textRef}
+          className="question-text"
+          dangerouslySetInnerHTML={{ __html: textHtml }}
+        />
+      )}
+      {question.resource_image && (
+        <img
+          src={question.resource_image}
+          alt="Question image"
+          className="question-image"
+          onClick={() => window.open(question.resource_image!, '_blank')}
+        />
+      )}
+      {renderOptions()}
+      {question.is_calculation && (
+        <div className="calculator">
+          <label htmlFor="calcInput">Answer</label>
+          <input type="number" id="calcInput" />
+          {question.answer_unit && <span className="unit">{question.answer_unit}</span>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QuestionRenderer;
+

--- a/src/pages/PracticeApp.tsx
+++ b/src/pages/PracticeApp.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import QuestionRenderer from '@/components/QuestionRenderer';
 import type { Question, PracticeResult } from '@/types/question';
 
 function loadQuestions(): Question[] {
@@ -55,21 +56,12 @@ export default function PracticeApp() {
   return (
     <div className="practice-app">
       <h2>Question {index + 1} of {questions.length}</h2>
-      <div className="question-text" dangerouslySetInnerHTML={{ __html: question.text }} />
-      <div className="options">
-        {question.answers.map(ans => (
-          <label key={ans.answer_number}>
-            <input
-              type="radio"
-              name="answer"
-              value={ans.answer_number}
-              checked={answers[question.id] === String(ans.answer_number)}
-              onChange={() => selectAnswer(String(ans.answer_number))}
-            />
-            {ans.text}
-          </label>
-        ))}
-      </div>
+      <QuestionRenderer
+        question={question}
+        variant="practice"
+        selectedAnswer={answers[question.id]}
+        onAnswerChange={selectAnswer}
+      />
       <div className="nav">
         <button onClick={back} disabled={index === 0}>Back</button>
         {index < questions.length - 1 ? (

--- a/src/styles/consolidated.css
+++ b/src/styles/consolidated.css
@@ -860,9 +860,6 @@ body {
 
 
 
-.question-options {
-  margin: var(--space-4) 0;
-}
 
 .calculator-section {
   display: flex;
@@ -1020,6 +1017,7 @@ body {
   border-color: var(--color-error);
   color: var(--color-white);
 }
+
 
 /* Calculator input */
 .calculator {

--- a/src/styles/practice.css
+++ b/src/styles/practice.css
@@ -834,6 +834,7 @@
   width: 100%;
 }
 
+
 /* Clean Summary Styling */
 .summary {
   padding: 40px;

--- a/src/styles/question.css
+++ b/src/styles/question.css
@@ -1,0 +1,85 @@
+/* Shared QuestionRenderer styles */
+.question-options {
+  display: flex;
+  flex-direction: column;
+  margin: var(--space-4) 0;
+}
+
+.question-options label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  text-align: left;
+}
+
+/* Index variant */
+.question-options.index {
+  gap: var(--space-3);
+  margin: var(--space-6) 0;
+}
+
+.question-options.index label {
+  padding: var(--space-4) var(--space-6);
+  background-color: var(--color-gray-50);
+  border: 2px solid var(--color-gray-200);
+  border-radius: var(--radius-lg);
+  transition: all var(--transition-normal);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+  min-height: 60px;
+}
+
+.question-options.index label:hover {
+  background-color: var(--color-gray-100);
+  border-color: var(--color-gray-300);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.question-options.index label.selected {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-white);
+}
+
+.question-options.index input[type="radio"] {
+  margin-right: var(--space-3);
+}
+
+/* Practice variant */
+.question-options.practice {
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.question-options.practice label {
+  padding: 15px 20px;
+  background-color: white;
+  border: 3px solid #3D505A;
+  border-radius: 8px;
+  transition: all 0.2s ease;
+  font-family: tahoma, geneva, sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+  word-wrap: break-word;
+  color: black;
+  min-height: 50px;
+}
+
+.question-options.practice label:hover {
+  border-color: #eab326;
+}
+
+.question-options.practice label.selected {
+  background-color: #f7d78c;
+  border-color: #3D505A;
+}
+
+.question-options.practice input[type="radio"] {
+  display: none;
+}
+
+.question-options.practice input[type="radio"] + span {
+  display: block;
+  width: 100%;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
   <title>GPhC Question Bank - Pharmacy Exam Preparation</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
   <link rel="stylesheet" href="/src/styles/consolidated.css">
+  <link rel="stylesheet" href="/src/styles/question.css">
 </head>
 <body>
   <div class="container">
@@ -48,15 +49,7 @@
 
         <!-- Single Question Section -->
         <div id="questionArea" class="question-container" style="display:none">
-          <div id="qText" class="question-text"></div>
-          <div id="qTitle" class="question-title"></div>
-          <img id="qImg" class="question-image" alt="Question image" style="display:none;">
-          <div id="answerOptions" class="options"></div>
-          <div class="calculator" style="display:none">
-            <label>Answer</label>
-            <input type="number" id="calcInput">
-            <span class="unit" id="answerUnit"></span>
-          </div>
+          <div id="questionRoot"></div>
           <div class="button-row">
             <button id="checkBtn" class="btn btn-primary">Check</button>
             <button id="revealBtn" class="btn btn-secondary">Reveal</button>

--- a/templates/practice.html
+++ b/templates/practice.html
@@ -6,6 +6,7 @@
   <title>Practice Test - GPhC Question Bank</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
   <link rel="stylesheet" href="../src/styles/consolidated.css">
+  <link rel="stylesheet" href="../src/styles/question.css">
   <link rel="stylesheet" href="../src/styles/practice.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- extract shared QuestionRenderer option styles into new `question.css`
- import the shared stylesheet on index and practice pages to remove duplicated CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fde012a8832bae3cfdd9671f06b7