### PR TITLE
refactor: use closest for view question button

### DIFF
--- a/src/components/questionStatistics.ts
+++ b/src/components/questionStatistics.ts
@@ -198,8 +198,9 @@ export class QuestionStatisticsComponent {
     }
 
     // View question button in table
-    if (target.classList.contains('view-question-btn')) {
-      const questionId = target.dataset.questionId;
+    const btn = (event.target as HTMLElement).closest('.view-question-btn') as HTMLElement | null;
+    if (btn) {
+      const questionId = btn.dataset.questionId;
       if (questionId) {
         this.handleViewQuestion(questionId);
       }


### PR DESCRIPTION
## Summary
- simplify question stats click handler by using `closest` on `.view-question-btn`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae9afa2cc4832bb1205c914743f8ce